### PR TITLE
feat: adding github actions for Azure and Aws

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -1,0 +1,82 @@
+name: Obsrv API service build and deploy workflow
+run-name: Workflow run for ${{ github.ref }}
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  check-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      ALLOWED_TAG: ${{ steps.tag-checker.outputs.TRIGGER_ALLOWED }}
+    steps:
+      - name: Check if tag is one in list of current releases
+        id: tag-checker
+        run: |
+          (echo -n TRIGGER_ALLOWED= && echo 'print("${{ github.ref_name }}".split("_")[0]
+          in ${{ vars.CURRENT_RELEASE }})' | python3) >> "$GITHUB_OUTPUT"
+
+  docker-build:
+    needs: check-tag
+    if: needs.check-tag.outputs.ALLOWED_TAG ==  'True'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to docker hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build docker image and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/obsrv-api-service:${{ github.ref_name }}
+
+  aws-deploy:
+    needs: [check-tag, docker-build]
+    if: needs.check-tag.outputs.ALLOWED_TAG ==  'True' && vars.CLOUD_PROVIDER == 'aws'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the terraform deployment repo
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ vars.DEPLOY_REPO }}
+          path: deploy
+          ref: ${{ vars.DEPLOY_REPO_REF }}
+
+      - name: Run terraform init and apply
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          cd deploy/terraform/aws
+          terraform init -backend-config terraform_backend.conf
+          terraform plan
+          #terraform apply -auto-approve
+
+  azure-deploy:
+    needs: [check-tag, docker-build]
+    if: needs.check-tag.outputs.ALLOWED_TAG ==  'True' && vars.CLOUD_PROVIDER == 'azure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the terraform deployment repo
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ vars.DEPLOY_REPO }}
+          path: deploy
+          ref: ${{ vars.DEPLOY_REPO_REF }}
+
+      - name: Run terraform init and apply
+        env:
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+        run: |
+          cd deploy/terraform/azure
+          terraform init -backend-config terraform_backend.conf
+          terraform plan
+          #terraform apply -auto-approve


### PR DESCRIPTION
### Github actions for terraform deployment on Azure and AWS 
- GitHub actions code supports Azure and AWS cloud and the actions
- The actions are triggered only on tag creation
- Following are the list of variables that are required for the actions to run

#### Action Variables
```
AWS_REGION                                 # AWS region. Example: us-east-2
CLOUD_PROVIDER                             # Cloud provider value. Example: aws OR azure
CURRENT_RELEASE                            # Accepts a list of tags that allow the workflow to run. Example: ["release-1.1.0", "release-1.1.1"]
DEPLOY_REPO                                # Location of the deployment repo. Example: keshavprasadms/obsrv-automation
DEPLOY_REPO_REF                            # Deploy repo branch or tag. Example: main
AWS_TERRAFORM_BACKEND_BUCKET_NAME          # AWS Terraform bucket name. This needs to be pre-created.
AWS_TERRAFORM_BACKEND_BUCKET_REGION        # AWS Terraform region
AZURE_TERRAFORM_BACKEND_RG                 # Azure Terraform resource group name. This needs to be pre-created.
AZURE_TERRAFORM_BACKEND_STORAGE_ACCOUNT    # Azure Terraform storage account name. This needs to be pre-created.
AZURE_TERRAFORM_BACKEND_CONTAINER          # Azure Terraform container name. This needs to be pre-created.
```

#### Action Secrets
```
DOCKERHUB_TOKEN             # Docker Hub Access Token
DOCKERHUB_USERNAME          # Docker Hub User Name
AWS_SECRET_ACCESS_KEY       # AWS Secret Key
AWS_ACCESS_KEY_ID           # AWS Access Key
ARM_TENANT_ID               # Azure Tenant Id
ARM_SUBSCRIPTION_ID         # Azure Subscription Id
ARM_CLIENT_SECRET           # Azure Client Secret
ARM_CLIENT_ID               # Azure Client Id
```

You can generate the azure secrets using the below sample command
```
az ad sp create-for-rbac --name "actions-testing" --role contributor --scopes /subscriptions/subscription-id --sdk-auth
```