### PR TITLE
#31 fix: cache validation schemas

### DIFF
--- a/src/configs/RoutesConfig.ts
+++ b/src/configs/RoutesConfig.ts
@@ -1,106 +1,125 @@
 export const routesConfig = {
   default: {
-    api_id: "obsrv.api"
+    api_id: "obsrv.api",
+    validation_schema: null,
   },
   query: {
     native_query: {
       api_id: "obsrv.native.query",
       method: "post",
-      path: "/obsrv/v1/query"
+      path: "/obsrv/v1/query",
+      validation_schema: "QueryRequest.json",
     },
     native_query_with_params: {
       api_id: "obsrv.native.query",
       method: "post",
-      path: "/obsrv/v1/query/:datasourceId"
+      path: "/obsrv/v1/query/:datasourceId",
+      validation_schema: "QueryRequest.json",
     },
     sql_query: {
       api_id: "obsrv.sql.query",
       method: "post",
-      path: "/obsrv/v1/sql-query"
+      path: "/obsrv/v1/sql-query",
+      validation_schema: "QueryRequest.json",
     },
     sql_query_with_params: {
       api_id: "obsrv.sql.query",
       method: "post",
-      path: "/obsrv/v1/sql-query/:datasourceId"
-    }
+      path: "/obsrv/v1/sql-query/:datasourceId",
+      validation_schema: "QueryRequest.json",
+    },
   },
   config: {
     dataset: {
       save: {
         api_id: "obsrv.config.dataset.create",
         method: "post",
-        path: "/obsrv/v1/datasets"
+        path: "/obsrv/v1/datasets",
+        validation_schema: "DatasetCreateReq.json",
       },
       read: {
         api_id: "obsrv.config.dataset.read",
         method: "get",
-        path: "/obsrv/v1/datasets/:datasetId"
+        path: "/obsrv/v1/datasets/:datasetId",
+        validation_schema: null,
       },
       update: {
         api_id: "obsrv.config.dataset.update",
         method: "patch",
-        path: "/obsrv/v1/datasets"
+        path: "/obsrv/v1/datasets",
+        validation_schema: "DatasetUpdateReq.json",
       },
       list: {
         api_id: "obsrv.config.dataset.list",
         method: "post",
-        path: "/obsrv/v1/datasets/list"
-      }
+        path: "/obsrv/v1/datasets/list",
+        validation_schema: "DatasetListReq.json",
+      },
     },
     datasource: {
       save: {
         api_id: "obsrv.config.datasource.create",
         method: "post",
-        path: "/obsrv/v1/datasources"
+        path: "/obsrv/v1/datasources",
+        validation_schema: "DatasourceSaveReq.json",
       },
       read: {
         api_id: "obsrv.config.datasource.read",
         method: "get",
-        path: "/obsrv/v1/datasources/:datasourceId"
+        path: "/obsrv/v1/datasources/:datasourceId",
+        validation_schema: null,
       },
       update: {
         api_id: "obsrv.config.datasource.update",
         method: "patch",
-        path: "/obsrv/v1/datasources"
+        path: "/obsrv/v1/datasources",
+        validation_schema: "DatasourceUpdateReq.json",
       },
       list: {
         api_id: "obsrv.config.datasource.list",
         method: "post",
-        path: "/obsrv/v1/datasources/list"
-      }
+        path: "/obsrv/v1/datasources/list",
+        validation_schema: "DatasetListReq.json",
+      },
     },
     dataset_source_config: {
       save: {
         api_id: "obsrv.config.dataset.source.config.create",
         method: "post",
-        path: "/obsrv/v1/datasets/source/config"
+        path: "/obsrv/v1/datasets/source/config",
+        validation_schema: "DatasetSourceConfigSaveReq.json",
       },
       read: {
         api_id: "obsrv.config.dataset.source.config.read",
         method: "get",
-        path: "/obsrv/v1/datasets/source/config/:datasetId"
+        path: "/obsrv/v1/datasets/source/config/:datasetId",
+        validation_schema: null,
       },
       update: {
         api_id: "obsrv.config.dataset.source.config.update",
         method: "patch",
-        path: "/obsrv/v1/datasets/source/config"
+        path: "/obsrv/v1/datasets/source/config",
+        validation_schema: "DatasetSourceConfigUpdateReq.json",
       },
       list: {
         api_id: "obsrv.config.dataset.source.config.list",
         method: "post",
-        path: "/obsrv/v1/datasets/source/config/list"
-      }
+        path: "/obsrv/v1/datasets/source/config/list",
+        validation_schema: "DatasetListReq.json",
+      },
     }
 
   },
   data_ingest: {
     api_id: "obsrv.dataset.data.in",
     method: "post",
-    path: "/obsrv/v1/data/:datasetId"
+    path: "/obsrv/v1/data/:datasetId",
+    validation_schema: "DataIngestionReq.json",
   },
   prometheus: {
     method: "get",
-    path: "/metrics"
-  }
+    path: "/metrics",
+    validation_schema: null,
+  },
 }
 

--- a/src/validators/RequestsValidator.ts
+++ b/src/validators/RequestsValidator.ts
@@ -4,29 +4,19 @@ import httpStatus from "http-status";
 import { IValidator } from "../models/DatasetModels";
 import { ValidationStatus } from "../models/ValidationModels";
 import { routesConfig } from "../configs/RoutesConfig";
+
 export class RequestsValidator implements IValidator {
     private schemaBasePath: string = "/src/resources/";
-    private reqSchemaMap = new Map<string, string>([
-        [routesConfig.query.native_query.api_id, "QueryRequest.json"],
-        [routesConfig.query.sql_query.api_id, "QueryRequest.json"],
-        [routesConfig.data_ingest.api_id, "DataIngestionReq.json"],
-        [routesConfig.config.dataset.save.api_id, "DatasetCreateReq.json"],
-        [routesConfig.config.datasource.save.api_id, "DatasourceSaveReq.json"],
-        [routesConfig.config.dataset.list.api_id, "DatasetListReq.json"],
-        [routesConfig.config.datasource.list.api_id, "DatasetListReq.json"],
-        [routesConfig.config.dataset.update.api_id, "DatasetUpdateReq.json"],
-        [routesConfig.config.datasource.update.api_id, "DatasourceUpdateReq.json"],
-        [routesConfig.config.dataset_source_config.save.api_id, "DatasetSourceConfigSaveReq.json"],
-        [routesConfig.config.dataset_source_config.update.api_id, "DatasetSourceConfigUpdateReq.json"],
-        [routesConfig.config.dataset_source_config.list.api_id, "DatasetListReq.json"],
-    ]);
+    private reqSchemaMap = new Map<string, any>();
     private validator: Ajv;
 
     constructor() {
-        this.validator = new Ajv()
+        this.validator = new Ajv();
+        this.loadSchemas();
     }
+
     validate(data: any, id: string): ValidationStatus {
-        return this.validateRequest(data, id)
+        return this.validateRequest(data, id);
     }
 
     private validateRequest(data: any, id: string): ValidationStatus {
@@ -40,9 +30,36 @@ export class RequestsValidator implements IValidator {
         }
     };
 
-    private getReqSchema(apiId: string): Object {
-        return JSON.parse(fs.readFileSync(process.cwd() + `${this.schemaBasePath}schemas/` + `${this.reqSchemaMap.get(apiId)}`, "utf8"));
+    private schemasMapping(): Record<string, any> {
+        return [
+            routesConfig.query.native_query,
+            routesConfig.query.sql_query,
+            routesConfig.data_ingest,
+            routesConfig.config.dataset.save,
+            routesConfig.config.datasource.save,
+            routesConfig.config.dataset.list,
+            routesConfig.config.datasource.list,
+            routesConfig.config.dataset.update,
+            routesConfig.config.datasource.update,
+            routesConfig.config.dataset_source_config.save,
+            routesConfig.config.dataset_source_config.update,
+            routesConfig.config.dataset_source_config.list,
+        ]
     }
 
+    private loadSchemas(): void {
+        this.schemasMapping().map((routeObject: Record<string, any>) =>
+            this.reqSchemaMap.set(routeObject.api_id, this.loadSchemaFromFile(routeObject.validation_schema))
+        )
+    }
 
+    private loadSchemaFromFile(filename: string): any {
+        const filePath = process.cwd() + `${this.schemaBasePath}schemas/` + filename;
+        const fileContent = fs.readFileSync(filePath, "utf8");
+        return JSON.parse(fileContent);
+    }
+
+    private getReqSchema(apiId: string): any {
+        return this.reqSchemaMap.get(apiId);
+    }
 }


### PR DESCRIPTION
PR for addition of following fix - 
* Performance improvement by reading the validation schemas and storing in cache on start of API service