### PR TITLE
Query API changes to support druid basic auth configuration

### DIFF
--- a/src/configs/Config.ts
+++ b/src/configs/Config.ts
@@ -5,6 +5,9 @@ export const config = {
   "body_parser_limit": process.env.body_parser_limit || "100mb",
   "query_api": {
     "druid": {
+      "druid_auth_enabled": process.env.druid_auth_enabled || false,
+      "druid_user": process.env.druid_admin_username || "",
+      "druid_password": process.env.druid_admin_password || "",
       "host": process.env.druid_host || "http://localhost",
       "port": process.env.druid_port || 8888,
       "sql_query_path": "/druid/v2/sql/",

--- a/src/connectors/DbConnector.ts
+++ b/src/connectors/DbConnector.ts
@@ -5,7 +5,7 @@ import { SchemaMerger } from "../generators/SchemaMerger";
 import constants from '../resources/Constants.json'
 import { config as appConfig } from "../configs/Config"
 import _ from 'lodash'
-import { wrapperService } from "../routes/Router";
+import { ingestorService } from "../routes/Router";
 const schemaMerger = new SchemaMerger()
 export class DbConnector implements IConnector {
     public pool: Knex
@@ -95,7 +95,7 @@ export class DbConnector implements IConnector {
 
     private async submit_ingestion(ingestion_spec: Record<string, any>, table: string) {
         if (appConfig.table_names.datasources === table) {
-            return await wrapperService.submitIngestion(ingestion_spec)
+            return await ingestorService.submitIngestionTask(ingestion_spec)
                 .catch((error: any) => {
                     console.error(constants.INGESTION_FAILED_ON_SAVE)
                     throw constants.FAILED_RECORD_UPDATE

--- a/src/connectors/HttpConnector.ts
+++ b/src/connectors/HttpConnector.ts
@@ -1,25 +1,38 @@
 import axios, { AxiosInstance } from "axios";
 import { IConnector } from "../models/DatasetModels";
+import { getAuthorizationHeader } from "../helpers/getAuthrorizationHeader";
+import { config } from "../configs/Config";
+
+
 export class HTTPConnector implements IConnector {
   private url: string;
+  private axiosInstance: AxiosInstance;
   constructor(url: string) {
-    this.url = url
-  }
-  connect(): AxiosInstance {
-    return axios.create({
+    const request: any = {}
+    request.headers = {
+      "Content-Type": "application/json",
+    }
+    if(url === `${config.query_api.druid.host}:${config.query_api.druid.port}`){
+      const customHeaders: any = getAuthorizationHeader()
+      request.headers = Object.assign(request.headers, customHeaders)
+    }
+    this.url = url;
+    this.axiosInstance = axios.create({
       baseURL: this.url,
       timeout: 3000,
-      headers: { "Content-Type": "application/json" }
+      headers: request.headers
     });
+  }
+
+  connect(): AxiosInstance {
+    return this.axiosInstance;
   }
 
   execute(sample: string) {
     throw new Error("Method not implemented.");
   }
+
   close() {
     throw new Error("Method not implemented.");
   }
-  
 }
-
-

--- a/src/helpers/getAuthrorizationHeader.ts
+++ b/src/helpers/getAuthrorizationHeader.ts
@@ -1,0 +1,16 @@
+import { config } from "../configs/Config";
+
+export const getAuthorizationHeader = () => {
+  const druidAuthEnabled = config.query_api.druid.druid_auth_enabled;
+  if (druidAuthEnabled) {
+    const druidUserName = config.query_api.druid.druid_user;
+    const druidUserPassword = config.query_api.druid.druid_password;
+    const credentials = `${druidUserName}:${druidUserPassword}`;
+    const base64Credentials = Buffer.from(credentials).toString('base64');
+    return {
+      "Authorization": `Basic ${base64Credentials}` 
+    };
+  } else {
+    return {};
+  }
+}

--- a/src/routes/Router.ts
+++ b/src/routes/Router.ts
@@ -19,9 +19,11 @@ import { onRequest } from "../helpers/prometheus/helpers";
 import promEntities from "../helpers/prometheus/entities";
 import { metricsScrapeHandler } from "../helpers/prometheus";
 
+export const datasourceConnector = new HTTPConnector(`${config.query_api.druid.host}:${config.query_api.druid.port}`)
+
 export const validationService = new ValidationService();
 
-export const queryService = new QueryService(new HTTPConnector(`${config.query_api.druid.host}:${config.query_api.druid.port}`));
+export const queryService = new QueryService(datasourceConnector);
 
 export const kafkaConnector = new KafkaConnector()
 
@@ -30,7 +32,7 @@ export const dbConnector = new DbConnector(config.db_connector_config);
 export const datasourceService = new DataSourceService(dbConnector, config.table_names.datasources);
 export const datasetService = new DatasetService(dbConnector, config.table_names.datasets);
 export const datasetSourceConfigService = new DatasetSourceConfigService(dbConnector, config.table_names.datasetSourceConfig);
-export const ingestorService = new IngestorService(kafkaConnector, new HTTPConnector(`${config.query_api.druid.host}:${config.query_api.druid.port}`));
+export const ingestorService = new IngestorService(kafkaConnector, datasourceConnector);
 export const exhaustService = new ClientCloudService(config.exhaust_config.cloud_storage_provider, config.exhaust_config.cloud_storage_config);
 export const wrapperService = new WrapperService();
 export const globalCache: any = new Map()

--- a/src/services/IngestorService.ts
+++ b/src/services/IngestorService.ts
@@ -8,7 +8,6 @@ import { refreshDatasetConfigs } from "../helpers/DatasetConfigs";
 import { IConnector } from "../models/DatasetModels";
 import { config } from '../configs/Config'
 import { AxiosInstance } from "axios";
-import { wrapperService } from "../routes/Router";
 export class IngestorService {
     private kafkaConnector: IConnector;
     private httpConnector: AxiosInstance
@@ -41,7 +40,7 @@ export class IngestorService {
     }
     public submitIngestion = async (req: Request, res: Response, next: NextFunction) => {
         try {
-            await wrapperService.submitIngestion(req.body)
+            await this.submitIngestionTask(req.body)
             ResponseHandler.successResponse(req, res, { status: 200, data: { message: constants.INGESTION_SUBMITTED } });
         }
         catch (error: any) {
@@ -81,4 +80,7 @@ export class IngestorService {
         }
     }
 
+    public async submitIngestionTask(ingestionSpec: object){
+        return await this.httpConnector.post(`${config.query_api.druid.host}:${config.query_api.druid.port}/${config.query_api.druid.submit_ingestion}`, ingestionSpec)
+    }
 }

--- a/src/services/IngestorService.ts
+++ b/src/services/IngestorService.ts
@@ -40,7 +40,8 @@ export class IngestorService {
     }
     public submitIngestion = async (req: Request, res: Response, next: NextFunction) => {
         try {
-            await this.submitIngestionTask(req.body)
+            let headers = req?.headers
+            await this.submitIngestionTask(req.body, headers)
             ResponseHandler.successResponse(req, res, { status: 200, data: { message: constants.INGESTION_SUBMITTED } });
         }
         catch (error: any) {
@@ -80,7 +81,7 @@ export class IngestorService {
         }
     }
 
-    public async submitIngestionTask(ingestionSpec: object){
-        return await this.httpConnector.post(`${config.query_api.druid.host}:${config.query_api.druid.port}/${config.query_api.druid.submit_ingestion}`, ingestionSpec)
+    public async submitIngestionTask(ingestionSpec: object, headers?: any){
+        return await this.httpConnector.post(`${config.query_api.druid.host}:${config.query_api.druid.port}/${config.query_api.druid.submit_ingestion}`, ingestionSpec, {headers})
     }
 }

--- a/src/services/QueryService.ts
+++ b/src/services/QueryService.ts
@@ -21,7 +21,8 @@ export class QueryService {
 
   public executeNativeQuery = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      var result = await this.connector.post(config.query_api.druid.native_query_path, req.body.query);
+      let headers = req?.headers
+      var result = await this.connector.post(config.query_api.druid.native_query_path, req.body.query, { headers });
       var mergedResult = result.data;
       if (req.body.query.queryType === "scan" && result.data) {
         mergedResult = result.data.map((item: Record<string, any>) => {
@@ -35,7 +36,8 @@ export class QueryService {
 
   public executeSqlQuery = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const result = await this.connector.post(config.query_api.druid.sql_query_path, req.body.querySql);
+      let headers = req?.headers
+      const result = await this.connector.post(config.query_api.druid.sql_query_path, req.body.querySql, { headers });
       ResponseHandler.successResponse(req, res, { status: result.status, data: result.data });
     } catch (error: any) { this.handleError(error, next); }
   }

--- a/src/services/WrapperService.ts
+++ b/src/services/WrapperService.ts
@@ -22,7 +22,7 @@ export class WrapperService {
     ) => {
         try {
             // console.log("SQL Request to druid - \n" + JSON.stringify({"ts": Date.now(), body: req.body, headers: req.headers}));
-            const authorization = req?.headers?.authorization;
+            const authorization = req?.headers?.authorization
             const result = await axios.post(
                 `${config.query_api.druid.host}:${config.query_api.druid.port}${config.query_api.druid.sql_query_path}`,
                 req.body, {
@@ -95,15 +95,16 @@ export class WrapperService {
         next: NextFunction
     ) => {
         try {
+            const headers = req?.headers;
             // console.log("Native STATUS Request to druid - \n" + JSON.stringify({"ts": Date.now(), body: req.body, headers: req.headers, url: req.url}));
             const result = await axios.get(
-                `${config.query_api.druid.host}:${config.query_api.druid.port}/status`
+                `${config.query_api.druid.host}:${config.query_api.druid.port}/status`,
+                {
+                    headers
+                }
             );
             ResponseHandler.flatResponse(req, res, result);
         } catch (error: any) { this.handleError(error, next); }
     };
 
-    public submitIngestion = async (ingestionSpec: object) => {
-        return await axios.post(`${config.query_api.druid.host}:${config.query_api.druid.port}/${config.query_api.druid.submit_ingestion}`, ingestionSpec)
-     }
 }

--- a/src/validators/QueryValidator.ts
+++ b/src/validators/QueryValidator.ts
@@ -10,7 +10,7 @@ import { dbConnector } from "../routes/Router";
 import { routesConfig } from "../configs/RoutesConfig";
 import { config } from "../configs/Config";
 import { isValidDateRange } from "../utils/common";
-import { HTTPConnector } from "../connectors/HttpConnector";
+import { datasourceConnector } from "../routes/Router";
 export class QueryValidator implements IValidator {
     private limits: ILimits;
     private momentFormat: string;
@@ -18,7 +18,7 @@ export class QueryValidator implements IValidator {
     constructor() {
         this.limits = queryRules
         this.momentFormat = "YYYY-MM-DD HH:MI:SS"
-        this.httpConnector = new HTTPConnector(`${config.query_api.druid.host}:${config.query_api.druid.port}`).connect()
+        this.httpConnector = datasourceConnector.connect()
     }
     public async validate(data: any, id: string): Promise<ValidationStatus> {
         let validationStatus


### PR DESCRIPTION
**Introduction** 

This PR includes changes in the query API, to support druid basic auth changes when enabled.

**Expected Outcome** 

The changes in the PR are expected to pull druid auth credentials from the environment, attaching to the default headers while calling druid url.

**Test Scenarios**

- [x]  Scenario -1 
Actual: When auth is disabled.
Expected: The previous API behavior should not change and able to allow user to query on datasources.
- [x] Scenario -2
Actual: When auth is enabled.
Expected: The API must fetch username and password from the environment variables, encrypt the username and password in required format(base64 in this case) and send it as part of deafult headers.