### PR TITLE
Sanketika-Obsrv/issue-tracker#OBS-151: feat: Generate ingestion spec before publish dataset

### DIFF
--- a/api-service/src/v2/controllers/DatasetCreate/DatasetCreateValidationSchema.json
+++ b/api-service/src/v2/controllers/DatasetCreate/DatasetCreateValidationSchema.json
@@ -131,11 +131,12 @@
                     "type": "string",
                     "minLength": 1
                   },
-                  "redis_db": {
-                    "type": "number"
+                  "dataset_id": {
+                    "type": "string",
+                    "minLength": 1
                   }
                 },
-                "required": ["denorm_key", "denorm_out_field", "redis_db"],
+                "required": ["denorm_key", "denorm_out_field", "dataset_id"],
                 "additionalProperties": false
               }
             }

--- a/api-service/src/v2/controllers/DatasetCreate/DatasetCreateValidationSchema.json
+++ b/api-service/src/v2/controllers/DatasetCreate/DatasetCreateValidationSchema.json
@@ -130,9 +130,12 @@
                   "denorm_out_field": {
                     "type": "string",
                     "minLength": 1
+                  },
+                  "redis_db": {
+                    "type": "number"
                   }
                 },
-                "required": ["denorm_key", "denorm_out_field"],
+                "required": ["denorm_key", "denorm_out_field", "redis_db"],
                 "additionalProperties": false
               }
             }
@@ -171,7 +174,29 @@
                 "minLength": 1
               },
               "transformation_function": {
-                "type": "object"
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "expr": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "condition": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "const": null
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["type", "expr"]
               },
               "mode": {
                 "type": "string",
@@ -188,8 +213,7 @@
             "required": [
               "field_key",
               "transformation_function",
-              "mode",
-              "metadata"
+              "mode"            
             ]
           }
         },
@@ -197,7 +221,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "minLength":1
+            "minLength": 1
           }
         }
       },

--- a/api-service/src/v2/controllers/DatasetStatusTransition/DatasetStatusTransition.ts
+++ b/api-service/src/v2/controllers/DatasetStatusTransition/DatasetStatusTransition.ts
@@ -158,7 +158,7 @@ const deleteDraftRecords = async (config: Record<string, any>) => {
 }
 
 //GENERATE_INGESTION_SPEC
-const generateDatasource = async (config: Record<string, any>) => {
+const generateIngestionSpec = async (config: Record<string, any>) => {
     const { dataset } = config;
     const dataSource = await generateDataSource(dataset);
     return DatasourceDraft.upsert(dataSource)
@@ -231,7 +231,7 @@ const restartPipeline = async (config: Record<string, any>) => {
 const commandExecutors = {
     DELETE_DRAFT_DATASETS: deleteDataset,
     PUBLISH_DATASET: publishDataset,
-    GENERATE_INGESTION_SPEC: generateDatasource,
+    GENERATE_INGESTION_SPEC: generateIngestionSpec,
     CHECK_DATASET_IS_DENORM: checkDatasetDenorm,
     SET_DATASET_TO_RETIRE: setDatasetRetired,
     DELETE_SUPERVISORS: deleteSupervisors,

--- a/api-service/src/v2/controllers/DatasetUpdate/DatasetUpdate.ts
+++ b/api-service/src/v2/controllers/DatasetUpdate/DatasetUpdate.ts
@@ -150,7 +150,7 @@ const checkDatasetExists = async (dataset_id: string, version_key: string): Prom
     if (datasetExists) {
         const validVersionKey = _.get(datasetExists, "version_key")
         const apiVersion = _.get(datasetExists, "api_version")
-        if (validVersionKey !== version_key && apiVersion) {
+        if (validVersionKey !== version_key && apiVersion === "v2") {
             return { isDatasetExists: true, datasetStatus: datasetExists.status, invalidVersionKey: true, validVersionKey }
         }
         return { isDatasetExists: true, datasetStatus: datasetExists.status }
@@ -344,7 +344,7 @@ const setDenormConfigs = (newDenormPayload: Record<string, any>, datasetDenormCo
     if (_.isEmpty(denorm_fields)) {
         return { denorm_fields }
     }
-    
+
     const getDenormPayload = (action: string) => {
         return _.compact(_.flatten(_.map(denorm_fields, payload => {
             if (payload.action == action) return payload.values

--- a/api-service/src/v2/controllers/DatasetUpdate/DatasetUpdateValidationSchema.json
+++ b/api-service/src/v2/controllers/DatasetUpdate/DatasetUpdateValidationSchema.json
@@ -321,7 +321,8 @@
                         "minLength": 1
                       }
                     },
-                    "required": ["denorm_out_field"]
+                    "required": ["denorm_out_field"],
+                    "additionalProperties": false
                   },
                   "action": {
                     "type": "string",

--- a/api-service/src/v2/controllers/DatasetUpdate/DatasetUpdateValidationSchema.json
+++ b/api-service/src/v2/controllers/DatasetUpdate/DatasetUpdateValidationSchema.json
@@ -316,8 +316,9 @@
                         "type": "string",
                         "minLength": 1
                       },
-                      "redis_db": {
-                        "type": "number"
+                      "dataset_id": {
+                        "type": "string",
+                        "minLength": 1
                       }
                     },
                     "required": ["denorm_out_field"]
@@ -339,7 +340,7 @@
                 "then": {
                   "properties": {
                     "values": {
-                      "required": ["denorm_key", "redis_db"]
+                      "required": ["denorm_key", "dataset_id"]
                     }
                   }
                 }

--- a/api-service/src/v2/controllers/DatasetUpdate/DatasetUpdateValidationSchema.json
+++ b/api-service/src/v2/controllers/DatasetUpdate/DatasetUpdateValidationSchema.json
@@ -218,7 +218,29 @@
                     "minLength": 1
                   },
                   "transformation_function": {
-                    "type": "object"
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "expr": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "condition": {
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "const": null
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": ["type", "expr"]
                   },
                   "mode": {
                     "type": "string",
@@ -293,6 +315,9 @@
                       "denorm_out_field": {
                         "type": "string",
                         "minLength": 1
+                      },
+                      "redis_db": {
+                        "type": "number"
                       }
                     },
                     "required": ["denorm_out_field"]
@@ -314,7 +339,7 @@
                 "then": {
                   "properties": {
                     "values": {
-                      "required": ["denorm_key"]
+                      "required": ["denorm_key", "redis_db"]
                     }
                   }
                 }

--- a/api-service/src/v2/services/IngestionService.ts
+++ b/api-service/src/v2/services/IngestionService.ts
@@ -211,8 +211,7 @@ export const getDruidIngestionTemplate = (payload: Record<string, any>) => {
                 "dimensionsSpec": { "dimensions": dimensions },
                 "timestampSpec": { "column": indexCol, "format": "auto" },
                 "metricsSpec": metrics,
-                "granularitySpec": getGranularityObj(),
-                "transformSpec": {}
+                "granularitySpec": getGranularityObj()
             },
             "tuningConfig": {
                 "type": "kafka",

--- a/api-service/src/v2/tests/DatasetManagement/DatasetCreate/Fixtures.ts
+++ b/api-service/src/v2/tests/DatasetManagement/DatasetCreate/Fixtures.ts
@@ -45,7 +45,7 @@ export const TestInputsForDatasetCreate = {
                     {
                         "denorm_key": "actor.id",
                         "denorm_out_field": "userdata",
-                        "redis_db": 10
+                        "dataset_id" : "master-telemetry"
                     }
                 ]
             },
@@ -327,7 +327,7 @@ export const TestInputsForDatasetCreate = {
                     {
                         "denorm_key": "actor.id",
                         "denorm_out_field": "userdata",
-                        "redis_db": 10
+                        "dataset_id" : "master-telemetry"
                     }
                 ]
             },
@@ -371,7 +371,7 @@ export const TestInputsForDatasetCreate = {
                     {
                         "denorm_key": "actor.id",
                         "denorm_out_field": "userdata",
-                        "redis_db": 10
+                        "dataset_id" : "master-telemetry"
                     }
                 ]
             },
@@ -424,7 +424,7 @@ export const TestInputsForDatasetCreate = {
                     {
                         "denorm_key": "actor.id",
                         "denorm_out_field": "userdata",
-                        "redis_db": 10
+                        "dataset_id" : "master-telemetry"
                     }
                 ]
             },
@@ -515,12 +515,12 @@ export const TestInputsForDatasetCreate = {
                     {
                         "denorm_key": "actor.id",
                         "denorm_out_field": "userdata",
-                        "redis_db": 10
+                        "dataset_id" : "master-telemetry"
                     },
                     {
                         "denorm_key": "actor.id",
                         "denorm_out_field": "userdata",
-                        "redis_db": 10
+                        "dataset_id" : "master-telemetry"
                     }
                 ]
             }

--- a/api-service/src/v2/tests/DatasetManagement/DatasetCreate/Fixtures.ts
+++ b/api-service/src/v2/tests/DatasetManagement/DatasetCreate/Fixtures.ts
@@ -44,7 +44,8 @@ export const TestInputsForDatasetCreate = {
                 "denorm_fields": [
                     {
                         "denorm_key": "actor.id",
-                        "denorm_out_field": "userdata"
+                        "denorm_out_field": "userdata",
+                        "redis_db": 10
                     }
                 ]
             },
@@ -325,7 +326,8 @@ export const TestInputsForDatasetCreate = {
                 "denorm_fields": [
                     {
                         "denorm_key": "actor.id",
-                        "denorm_out_field": "userdata"
+                        "denorm_out_field": "userdata",
+                        "redis_db": 10
                     }
                 ]
             },
@@ -368,7 +370,8 @@ export const TestInputsForDatasetCreate = {
                 "denorm_fields": [
                     {
                         "denorm_key": "actor.id",
-                        "denorm_out_field": "userdata"
+                        "denorm_out_field": "userdata",
+                        "redis_db": 10
                     }
                 ]
             },
@@ -420,7 +423,8 @@ export const TestInputsForDatasetCreate = {
                 "denorm_fields": [
                     {
                         "denorm_key": "actor.id",
-                        "denorm_out_field": "userdata"
+                        "denorm_out_field": "userdata",
+                        "redis_db": 10
                     }
                 ]
             },
@@ -510,11 +514,13 @@ export const TestInputsForDatasetCreate = {
                 "denorm_fields": [
                     {
                         "denorm_key": "actor.id",
-                        "denorm_out_field": "userdata"
+                        "denorm_out_field": "userdata",
+                        "redis_db": 10
                     },
                     {
                         "denorm_key": "actor.id",
-                        "denorm_out_field": "userdata"
+                        "denorm_out_field": "userdata",
+                        "redis_db": 10
                     }
                 ]
             }

--- a/api-service/src/v2/tests/DatasetManagement/DatasetList/Fixtures.ts
+++ b/api-service/src/v2/tests/DatasetManagement/DatasetList/Fixtures.ts
@@ -48,7 +48,7 @@ export const TestInputsForDatasetList = {
                 {
                     "denorm_key": "actor.id",
                     "denorm_out_field": "userdata",
-                    "redis_db": 10
+                    "dataset_id" : "master-telemetry"
                 }
             ]
         },
@@ -123,7 +123,7 @@ export const TestInputsForDatasetList = {
                 {
                     "denorm_key": "actor.id",
                     "denorm_out_field": "userdata",
-                    "redis_db": 10
+                    "dataset_id" : "master-telemetry"
                 }
             ]
         },

--- a/api-service/src/v2/tests/DatasetManagement/DatasetList/Fixtures.ts
+++ b/api-service/src/v2/tests/DatasetManagement/DatasetList/Fixtures.ts
@@ -47,7 +47,8 @@ export const TestInputsForDatasetList = {
             "denorm_fields": [
                 {
                     "denorm_key": "actor.id",
-                    "denorm_out_field": "userdata"
+                    "denorm_out_field": "userdata",
+                    "redis_db": 10
                 }
             ]
         },
@@ -121,7 +122,8 @@ export const TestInputsForDatasetList = {
             "denorm_fields": [
                 {
                     "denorm_key": "actor.id",
-                    "denorm_out_field": "userdata"
+                    "denorm_out_field": "userdata",
+                    "redis_db": 10
                 }
             ]
         },

--- a/api-service/src/v2/tests/DatasetManagement/DatasetRead/Fixtures.ts
+++ b/api-service/src/v2/tests/DatasetManagement/DatasetRead/Fixtures.ts
@@ -48,7 +48,7 @@ export const TestInputsForDatasetRead = {
                 {
                     "denorm_key": "actor.id",
                     "denorm_out_field": "userdata",
-                    "redis_db": 10
+                    "dataset_id" : "master-telemetry"
                 }
             ]
         },
@@ -124,7 +124,7 @@ export const TestInputsForDatasetRead = {
                 {
                     "denorm_key": "actor.id",
                     "denorm_out_field": "userdata",
-                    "redis_db": 10
+                    "dataset_id" : "master-telemetry"
                 }
             ]
         },

--- a/api-service/src/v2/tests/DatasetManagement/DatasetRead/Fixtures.ts
+++ b/api-service/src/v2/tests/DatasetManagement/DatasetRead/Fixtures.ts
@@ -47,7 +47,8 @@ export const TestInputsForDatasetRead = {
             "denorm_fields": [
                 {
                     "denorm_key": "actor.id",
-                    "denorm_out_field": "userdata"
+                    "denorm_out_field": "userdata",
+                    "redis_db": 10
                 }
             ]
         },
@@ -122,7 +123,8 @@ export const TestInputsForDatasetRead = {
             "denorm_fields": [
                 {
                     "denorm_key": "actor.id",
-                    "denorm_out_field": "userdata"
+                    "denorm_out_field": "userdata",
+                    "redis_db": 10
                 }
             ]
         },

--- a/api-service/src/v2/tests/DatasetManagement/DatasetStatusTransition/DatasetLive.spec.ts
+++ b/api-service/src/v2/tests/DatasetManagement/DatasetStatusTransition/DatasetLive.spec.ts
@@ -10,6 +10,8 @@ import { TestInputsForDatasetStatusTransition } from "./Fixtures";
 import { DatasetDraft } from "../../../models/DatasetDraft";
 import { commandHttpService } from "../../../connections/commandServiceConnection";
 import { sequelize } from "../../../connections/databaseConnection";
+import { DatasourceDraft } from "../../../models/DatasourceDraft";
+import { DatasetTransformationsDraft } from "../../../models/TransformationDraft";
 
 chai.use(spies);
 chai.should();
@@ -25,7 +27,13 @@ describe("DATASET STATUS TRANSITION LIVE", () => {
 
     it("Dataset status transition success: When the action is to set dataset live", (done) => {
         chai.spy.on(DatasetDraft, "findOne", () => {
-            return Promise.resolve({ dataset_id: "telemetry", status: "ReadyToPublish" })
+            return Promise.resolve(TestInputsForDatasetStatusTransition.VALID_SCHEMA_FOR_LIVE_READ)
+        })
+        chai.spy.on(DatasetTransformationsDraft, "findAll", () => {
+            return Promise.resolve([])
+        })
+        chai.spy.on(DatasourceDraft, "upsert", () => {
+            return Promise.resolve({})
         })
         chai.spy.on(commandHttpService, "post", () => {
             return Promise.resolve({})

--- a/api-service/src/v2/tests/DatasetManagement/DatasetStatusTransition/Fixtures.ts
+++ b/api-service/src/v2/tests/DatasetManagement/DatasetStatusTransition/Fixtures.ts
@@ -1,187 +1,219 @@
 export const TestInputsForDatasetStatusTransition = {
-    VALID_SCHEMA_FOR_DELETE: {
-        "id": "api.datasets.status-transition",
-        "ver": "v2",
-        "ts": "2024-04-19T12:58:47+05:30",
-        "params": {
-            "msgid": "4a7f14c3-d61e-4d4f-be78-181834eeff6"
-        },
-        "request": {
-            "dataset_id": "telemetry.1",
-            "status": "Delete"
-        }
+  VALID_SCHEMA_FOR_DELETE: {
+    "id": "api.datasets.status-transition",
+    "ver": "v2",
+    "ts": "2024-04-19T12:58:47+05:30",
+    "params": {
+      "msgid": "4a7f14c3-d61e-4d4f-be78-181834eeff6"
     },
-    VALID_SCHEMA_FOR_LIVE: {
-        "id": "api.datasets.status-transition",
-        "ver": "v2",
-        "ts": "2024-04-19T12:58:47+05:30",
-        "params": {
-            "msgid": "4a7f14c3-d61e-4d4f-be78-181834eeff6"
-        },
-        "request": {
-            "dataset_id": "telemetry.1",
-            "status": "Live"
-        }
+    "request": {
+      "dataset_id": "telemetry.1",
+      "status": "Delete"
+    }
+  },
+  VALID_SCHEMA_FOR_LIVE: {
+    "id": "api.datasets.status-transition",
+    "ver": "v2",
+    "ts": "2024-04-19T12:58:47+05:30",
+    "params": {
+      "msgid": "4a7f14c3-d61e-4d4f-be78-181834eeff6"
     },
-    VALID_SCHEMA_FOR_RETIRE: {
-        "id": "api.datasets.status-transition",
-        "ver": "v2",
-        "ts": "2024-04-19T12:58:47+05:30",
-        "params": {
-            "msgid": "4a7f14c3-d61e-4d4f-be78-181834eeff6"
-        },
-        "request": {
-            "dataset_id": "telemetry",
-            "status": "Retire"
-        }
+    "request": {
+      "dataset_id": "telemetry.1",
+      "status": "Live"
+    }
+  },
+  VALID_SCHEMA_FOR_RETIRE: {
+    "id": "api.datasets.status-transition",
+    "ver": "v2",
+    "ts": "2024-04-19T12:58:47+05:30",
+    "params": {
+      "msgid": "4a7f14c3-d61e-4d4f-be78-181834eeff6"
     },
-    INVALID_SCHEMA: {
-        "id": "api.datasets.status-transition",
-        "ver": "v2",
-        "ts": "2024-04-19T12:58:47+05:30",
-        "params": {
-            "msgid": "4a7f14c3-d61e-4d4f-be78-181834eeff6"
-        },
-        "request": {
-            "dataset_id": "telemetry.1",
-            "status": ""
-        }
+    "request": {
+      "dataset_id": "telemetry",
+      "status": "Retire"
+    }
+  },
+  INVALID_SCHEMA: {
+    "id": "api.datasets.status-transition",
+    "ver": "v2",
+    "ts": "2024-04-19T12:58:47+05:30",
+    "params": {
+      "msgid": "4a7f14c3-d61e-4d4f-be78-181834eeff6"
     },
-    VALID_REQUEST_FOR_READY_FOR_PUBLISH:{
-        "id": "api.datasets.status-transition",
-        "ver": "v2",
-        "ts": "2024-04-19T12:58:47+05:30",
-        "params": {
-            "msgid": "4a7f14c3-d61e-4d4f-be78-181834eeff6"
-        },
-        "request": {
-            "dataset_id": "telemetry.1",
-            "status": "ReadyToPublish"
-        }
+    "request": {
+      "dataset_id": "telemetry.1",
+      "status": ""
+    }
+  },
+  VALID_REQUEST_FOR_READY_FOR_PUBLISH: {
+    "id": "api.datasets.status-transition",
+    "ver": "v2",
+    "ts": "2024-04-19T12:58:47+05:30",
+    "params": {
+      "msgid": "4a7f14c3-d61e-4d4f-be78-181834eeff6"
     },
-    VALID_SCHEMA_FOR_READY_TO_PUBLISH: {
-        "dataset_id": "telemetry",
-        "type": "dataset",
-        "name": "sb-telemetry",
-        "id": "telemetry.1",
-        "status": "Draft",
-        "version_key": "1789887878",
-        "validation_config": {
-          "validate": true,
-          "mode": "Strict"
+    "request": {
+      "dataset_id": "telemetry.1",
+      "status": "ReadyToPublish"
+    }
+  },
+  VALID_SCHEMA_FOR_READY_TO_PUBLISH: {
+    "dataset_id": "telemetry",
+    "type": "dataset",
+    "name": "sb-telemetry",
+    "id": "telemetry.1",
+    "status": "Draft",
+    "version_key": "1789887878",
+    "validation_config": {
+      "validate": true,
+      "mode": "Strict"
+    },
+    "extraction_config": {
+      "is_batch_event": true,
+      "extraction_key": "events",
+      "batch_id": "id",
+      "dedup_config": {
+        "drop_duplicates": true,
+        "dedup_key": "id",
+        "dedup_period": 3783
+      }
+    },
+    "dedup_config": {
+      "drop_duplicates": true,
+      "dedup_key": "mid",
+      "dedup_period": 3783
+    },
+    "data_schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "ets": {
+          "type": "string"
         },
-        "extraction_config": {
-          "is_batch_event": true,
-          "extraction_key": "events",
-          "batch_id": "id",
-          "dedup_config": {
-            "drop_duplicates": true,
-            "dedup_key": "id",
-            "dedup_period": 3783
-          }
+        "ver": {
+          "type": "string"
         },
-        "dedup_config": {
-          "drop_duplicates": true,
-          "dedup_key": "mid",
-          "dedup_period": 3783
-        },
-        "data_schema": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "type": "object",
-          "properties": {
-            "ets": {
-              "type": "string"
-            },
-            "ver": {
-              "type": "string"
-            },
-            "required": [
-              "eid"
-            ]
-          },
-          "additionalProperties": true
-        },
-        "router_config": {
-          "topic": "test"
-        },
-        "denorm_config": {
-          "redis_db_host": "local",
-          "redis_db_port": 5432,
-          "denorm_fields": [
-            {
-              "denorm_key": "actor.id",
-              "denorm_out_field": "userdata",
-              "dataset_name": "name",
-              "dataset_id": "name"
-            },
-            {
-              "denorm_key": "actor.id",
-              "denorm_out_field": "mid",
-              "dataset_name": "name",
-              "dataset_id": "name"
-            }
-          ]
-        },
-        "dataset_config": {
-          "data_key": "mid",
-          "timestamp_key": "ets",
-          "entry_topic": "topic",
-          "redis_db_host": "local",
-          "redis_db_port": 5432,
-          "redis_db": 0,
-          "index_data": true
-        },
-        "client_state": {},
-        "tags": [
-          "tag1",
-          "tag2"
+        "required": [
+          "eid"
         ]
       },
-      INVALID_SCHEMA_FOR_READY_TO_PUBLISH: {
-        "dataset_id": "telemetry",
-        "type": "",
-        "name": "sb-telemetry",
-        "id": "telemetry.1",
-        "status": "Draft",
-        "version_key": "1789887878",
-        "validation_config": {
-          "validate": true,
-          "mode": "Strict"
+      "additionalProperties": true
+    },
+    "router_config": {
+      "topic": "test"
+    },
+    "denorm_config": {
+      "redis_db_host": "local",
+      "redis_db_port": 5432,
+      "denorm_fields": [
+        {
+          "denorm_key": "actor.id",
+          "denorm_out_field": "userdata",
+          "dataset_name": "name",
+          "dataset_id": "name",
+          "redis_db": 10
         },
-        "router_config": {
-          "topic": "test"
+        {
+          "denorm_key": "actor.id",
+          "denorm_out_field": "mid",
+          "dataset_name": "name",
+          "dataset_id": "name",
+          "redis_db": 15
+        }
+      ]
+    },
+    "dataset_config": {
+      "data_key": "mid",
+      "timestamp_key": "ets",
+      "entry_topic": "topic",
+      "redis_db_host": "local",
+      "redis_db_port": 5432,
+      "redis_db": 0,
+      "index_data": true
+    },
+    "client_state": {},
+    "tags": [
+      "tag1",
+      "tag2"
+    ]
+  },
+  INVALID_SCHEMA_FOR_READY_TO_PUBLISH: {
+    "dataset_id": "telemetry",
+    "type": "",
+    "name": "sb-telemetry",
+    "id": "telemetry.1",
+    "status": "Draft",
+    "version_key": "1789887878",
+    "validation_config": {
+      "validate": true,
+      "mode": "Strict"
+    },
+    "router_config": {
+      "topic": "test"
+    },
+    "denorm_config": {
+      "redis_db_host": "local",
+      "redis_db_port": 5432,
+      "denorm_fields": [
+        {
+          "denorm_key": "actor.id",
+          "denorm_out_field": "userdata",
+          "dataset_name": "name",
+          "dataset_id": "name",
+          "redis_db": 15
         },
-        "denorm_config": {
-          "redis_db_host": "local",
-          "redis_db_port": 5432,
-          "denorm_fields": [
-            {
-              "denorm_key": "actor.id",
-              "denorm_out_field": "userdata",
-              "dataset_name": "name",
-              "dataset_id": "name"
-            },
-            {
-              "denorm_key": "actor.id",
-              "denorm_out_field": "mid",
-              "dataset_name": "name",
-              "dataset_id": "name"
-            }
-          ]
+        {
+          "denorm_key": "actor.id",
+          "denorm_out_field": "mid",
+          "dataset_name": "name",
+          "dataset_id": "name",
+          "redis_db": 23
+        }
+      ]
+    },
+    "dataset_config": {
+      "data_key": "mid",
+      "timestamp_key": "ets",
+      "entry_topic": "topic",
+      "redis_db_host": "local",
+      "redis_db_port": 5432,
+      "redis_db": 0,
+      "index_data": true
+    },
+    "client_state": {},
+    "tags": [
+      "tag1",
+      "tag2"
+    ]
+  },
+
+  VALID_SCHEMA_FOR_LIVE_READ: {
+    "dataset_id": "sb-ddd",
+    "type": "dataset",
+    "name": "sb-telemetry2",
+    "status": "ReadyToPublish",
+    "data_schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "ets": {
+          "type": "string"
         },
-        "dataset_config": {
-          "data_key": "mid",
-          "timestamp_key": "ets",
-          "entry_topic": "topic",
-          "redis_db_host": "local",
-          "redis_db_port": 5432,
-          "redis_db": 0,
-          "index_data": true
+        "ver": {
+          "type": "string"
         },
-        "client_state": {},
-        "tags": [
-          "tag1",
-          "tag2"
+        "required": [
+          "eid"
         ]
-      }
+      },
+      "additionalProperties": true
+    },
+    "dataset_config": {
+      "data_key": "",
+      "timestamp_key": "ets"
+    },
+    "tags": []
+  }
 }

--- a/api-service/src/v2/tests/DatasetManagement/DatasetStatusTransition/Fixtures.ts
+++ b/api-service/src/v2/tests/DatasetManagement/DatasetStatusTransition/Fixtures.ts
@@ -112,15 +112,13 @@ export const TestInputsForDatasetStatusTransition = {
           "denorm_key": "actor.id",
           "denorm_out_field": "userdata",
           "dataset_name": "name",
-          "dataset_id": "name",
-          "redis_db": 10
+          "dataset_id": "name"
         },
         {
           "denorm_key": "actor.id",
           "denorm_out_field": "mid",
           "dataset_name": "name",
-          "dataset_id": "name",
-          "redis_db": 15
+          "dataset_id": "name"
         }
       ]
     },
@@ -161,15 +159,13 @@ export const TestInputsForDatasetStatusTransition = {
           "denorm_key": "actor.id",
           "denorm_out_field": "userdata",
           "dataset_name": "name",
-          "dataset_id": "name",
-          "redis_db": 15
+          "dataset_id": "name"
         },
         {
           "denorm_key": "actor.id",
           "denorm_out_field": "mid",
           "dataset_name": "name",
-          "dataset_id": "name",
-          "redis_db": 23
+          "dataset_id": "name"
         }
       ]
     },

--- a/api-service/src/v2/tests/DatasetManagement/DatasetUpdate/DatasetDenorm.spec.ts
+++ b/api-service/src/v2/tests/DatasetManagement/DatasetUpdate/DatasetDenorm.spec.ts
@@ -9,6 +9,7 @@ import _ from "lodash";
 import { TestInputsForDatasetUpdate, msgid, validVersionKey } from "./Fixtures";
 import { apiId } from "../../../controllers/DatasetUpdate/DatasetUpdate"
 import { sequelize } from "../../../connections/databaseConnection";
+import { Dataset } from "../../../models/Dataset";
 
 chai.use(spies);
 chai.should();
@@ -28,6 +29,9 @@ describe("DATASET DENORM UPDATE", () => {
         })
         chai.spy.on(DatasetDraft, "update", () => {
             return Promise.resolve({ dataValues: { id: "telemetry", message: "Dataset is updated successfully" } })
+        })
+        chai.spy.on(Dataset, "findAll", () => {
+            return Promise.resolve([{ "dataset_id": "master-telemetry", "dataset_config": { "redis_db": 15 } }])
         })
         const t = chai.spy.on(sequelize, "transaction", () => {
             return Promise.resolve(sequelize.transaction)
@@ -91,6 +95,7 @@ describe("DATASET DENORM UPDATE", () => {
                     denorm_fields: [{
                         "denorm_key": "actor.id",
                         "denorm_out_field": "mid",
+                        "dataset_id" : "master-telemetry",
                         "redis_db": 10
                     }]
                 }
@@ -150,16 +155,11 @@ describe("DATASET DENORM UPDATE", () => {
                     denorm_fields: [{
                         "denorm_key": "actor.id",
                         "denorm_out_field": "userdata",
+                        "dataset_id" : "master-telemetry",
                         "redis_db": 10
                     }]
                 }
             })
-        })
-        const t = chai.spy.on(sequelize, "transaction", () => {
-            return Promise.resolve(sequelize.transaction)
-        })
-        chai.spy.on(t, "rollback", () => {
-            return Promise.resolve({})
         })
         chai
             .request(app)
@@ -184,6 +184,7 @@ describe("DATASET DENORM UPDATE", () => {
                     denorm_fields: [{
                         "denorm_key": "actor.id",
                         "denorm_out_field": "id",
+                        "dataset_id" : "master-telemetry",
                         "redis_db": 10
                     }]
                 }
@@ -201,6 +202,31 @@ describe("DATASET DENORM UPDATE", () => {
                 res.body.params.msgid.should.be.eq(msgid)
                 res.body.error.message.should.be.eq("Denorm fields do not exist to remove")
                 res.body.error.code.should.be.eq("DATASET_DENORM_DO_NOT_EXIST")
+                done();
+            });
+    });
+
+    it("Failure: Master dataset not found as denorm", (done) => {
+        chai.spy.on(DatasetDraft, "findOne", () => {
+            return Promise.resolve({
+                id: "telemetry", status: "Draft", type:"dataset", version_key: validVersionKey, denorm_config: { denorm_field: [] }
+            })
+        })
+        chai.spy.on(Dataset, "findAll", () => {
+            return Promise.resolve([{ "dataset_id": "trip-events", "dataset_config": { "redis_db": 15 } }])
+        })
+        chai
+            .request(app)
+            .patch("/v2/datasets/update")
+            .send(TestInputsForDatasetUpdate.DATASET_UPDATE_DENORM_ADD)
+            .end((err, res) => {
+                res.should.have.status(httpStatus.NOT_FOUND);
+                res.body.should.be.a("object")
+                res.body.id.should.be.eq(apiId);
+                res.body.params.status.should.be.eq("FAILED")
+                res.body.params.msgid.should.be.eq(msgid)
+                res.body.error.message.should.be.eq("Denorm Master dataset not found")
+                res.body.error.code.should.be.eq("DATASET_DENORM_NOT_FOUND")
                 done();
             });
     });

--- a/api-service/src/v2/tests/DatasetManagement/DatasetUpdate/DatasetDenorm.spec.ts
+++ b/api-service/src/v2/tests/DatasetManagement/DatasetUpdate/DatasetDenorm.spec.ts
@@ -90,7 +90,8 @@ describe("DATASET DENORM UPDATE", () => {
                 id: "telemetry", version_key: validVersionKey, type:"dataset", status: "Draft", denorm_config: {
                     denorm_fields: [{
                         "denorm_key": "actor.id",
-                        "denorm_out_field": "mid"
+                        "denorm_out_field": "mid",
+                        "redis_db": 10
                     }]
                 }
             })
@@ -148,7 +149,8 @@ describe("DATASET DENORM UPDATE", () => {
                 id: "telemetry", status: "Draft", version_key: validVersionKey, tags: ["tag1", "tag2"], denorm_config: {
                     denorm_fields: [{
                         "denorm_key": "actor.id",
-                        "denorm_out_field": "userdata"
+                        "denorm_out_field": "userdata",
+                        "redis_db": 10
                     }]
                 }
             })
@@ -181,7 +183,8 @@ describe("DATASET DENORM UPDATE", () => {
                 id: "telemetry", status: "Draft", version_key: validVersionKey, tags: ["tag1", "tag2"], denorm_config: {
                     denorm_fields: [{
                         "denorm_key": "actor.id",
-                        "denorm_out_field": "id"
+                        "denorm_out_field": "id",
+                        "redis_db": 10
                     }]
                 }
             })

--- a/api-service/src/v2/tests/DatasetManagement/DatasetUpdate/DatasetTransformation.spec.ts
+++ b/api-service/src/v2/tests/DatasetManagement/DatasetUpdate/DatasetTransformation.spec.ts
@@ -10,6 +10,7 @@ import { TestInputsForDatasetUpdate, msgid, validVersionKey } from "./Fixtures";
 import { DatasetTransformationsDraft } from "../../../models/TransformationDraft";
 import { apiId } from "../../../controllers/DatasetUpdate/DatasetUpdate"
 import { sequelize } from "../../../connections/databaseConnection";
+import { Dataset } from "../../../models/Dataset";
 
 chai.use(spies);
 chai.should();
@@ -184,6 +185,7 @@ describe("DATASET TRANSFORMATIONS UPDATE", () => {
                     denorm_fields: [{
                         "denorm_key": "actor.id",
                         "denorm_out_field": "mid",
+                        "dataset_id" : "master-telemetry",
                         "redis_db": 10
                     }]
                 }
@@ -191,6 +193,9 @@ describe("DATASET TRANSFORMATIONS UPDATE", () => {
         })
         chai.spy.on(DatasetTransformationsDraft, "findAll", () => {
             return Promise.resolve([{ field_key: "key1" }, { field_key: "key3" }])
+        })
+        chai.spy.on(Dataset, "findAll", () => {
+            return Promise.resolve([{ "dataset_id": "master-telemetry", "dataset_config": { "redis_db": 15 } }])
         })
         const t = chai.spy.on(sequelize, "transaction", () => {
             return Promise.resolve(sequelize.transaction)
@@ -221,6 +226,7 @@ describe("DATASET TRANSFORMATIONS UPDATE", () => {
                     denorm_fields: [{
                         "denorm_key": "actor.id",
                         "denorm_out_field": "mid",
+                        "dataset_id" : "master-telemetry",
                         "redis_db": 10
                     }]
                 }
@@ -228,6 +234,9 @@ describe("DATASET TRANSFORMATIONS UPDATE", () => {
         })
         chai.spy.on(DatasetTransformationsDraft, "findAll", () => {
             return Promise.resolve([{ field_key: "key7" }, { field_key: "key2" }])
+        })
+        chai.spy.on(Dataset, "findAll", () => {
+            return Promise.resolve([{ "dataset_id": "master-telemetry", "dataset_config": { "redis_db": 15 } }])
         })
         const t = chai.spy.on(sequelize, "transaction", () => {
             return Promise.resolve(sequelize.transaction)
@@ -258,6 +267,7 @@ describe("DATASET TRANSFORMATIONS UPDATE", () => {
                     denorm_fields: [{
                         "denorm_key": "actor.id",
                         "denorm_out_field": "mid",
+                        "dataset_id" : "master-telemetry",
                         "redis_db": 10
                     }]
                 }
@@ -265,6 +275,9 @@ describe("DATASET TRANSFORMATIONS UPDATE", () => {
         })
         chai.spy.on(DatasetTransformationsDraft, "findAll", () => {
             return Promise.resolve([{ field_key: "key7" }, { field_key: "key3" }])
+        })
+        chai.spy.on(Dataset, "findAll", () => {
+            return Promise.resolve([{ "dataset_id": "master-telemetry", "dataset_config": { "redis_db": 15 } }])
         })
         const t = chai.spy.on(sequelize, "transaction", () => {
             return Promise.resolve(sequelize.transaction)

--- a/api-service/src/v2/tests/DatasetManagement/DatasetUpdate/DatasetTransformation.spec.ts
+++ b/api-service/src/v2/tests/DatasetManagement/DatasetUpdate/DatasetTransformation.spec.ts
@@ -183,7 +183,8 @@ describe("DATASET TRANSFORMATIONS UPDATE", () => {
                 id: "telemetry", status: "Draft",  type:"dataset", version_key: validVersionKey, tags: ["tag1", "tag2"], denorm_config: {
                     denorm_fields: [{
                         "denorm_key": "actor.id",
-                        "denorm_out_field": "mid"
+                        "denorm_out_field": "mid",
+                        "redis_db": 10
                     }]
                 }
             })
@@ -219,7 +220,8 @@ describe("DATASET TRANSFORMATIONS UPDATE", () => {
                 id: "telemetry", status: "Draft", type:"dataset" , version_key: validVersionKey, tags: ["tag1", "tag2"], denorm_config: {
                     denorm_fields: [{
                         "denorm_key": "actor.id",
-                        "denorm_out_field": "mid"
+                        "denorm_out_field": "mid",
+                        "redis_db": 10
                     }]
                 }
             })
@@ -255,7 +257,8 @@ describe("DATASET TRANSFORMATIONS UPDATE", () => {
                 id: "telemetry", status: "Draft", type:"dataset", version_key: validVersionKey, tags: ["tag1", "tag2"], denorm_config: {
                     denorm_fields: [{
                         "denorm_key": "actor.id",
-                        "denorm_out_field": "mid"
+                        "denorm_out_field": "mid",
+                        "redis_db": 10
                     }]
                 }
             })

--- a/api-service/src/v2/tests/DatasetManagement/DatasetUpdate/DatasetUpdate.spec.ts
+++ b/api-service/src/v2/tests/DatasetManagement/DatasetUpdate/DatasetUpdate.spec.ts
@@ -59,7 +59,8 @@ describe("DATASET UPDATE API", () => {
                 id: "telemetry", status: "Draft", type: "dataset", version_key: validVersionKey, tags: ["tag1", "tag2"], denorm_config: {
                     denorm_fields: [{
                         "denorm_key": "actor.id",
-                        "denorm_out_field": "mid"
+                        "denorm_out_field": "mid",
+                        "redis_db": 10
                     }]
                 }
             })

--- a/api-service/src/v2/tests/DatasetManagement/DatasetUpdate/DatasetUpdate.spec.ts
+++ b/api-service/src/v2/tests/DatasetManagement/DatasetUpdate/DatasetUpdate.spec.ts
@@ -60,6 +60,7 @@ describe("DATASET UPDATE API", () => {
                     denorm_fields: [{
                         "denorm_key": "actor.id",
                         "denorm_out_field": "mid",
+                        "dataset_id" : "master-telemetry",
                         "redis_db": 10
                     }]
                 }
@@ -76,6 +77,9 @@ describe("DATASET UPDATE API", () => {
                     "additionalProperties": true
                 },
             })
+        })
+        chai.spy.on(Dataset, "findAll", () => {
+            return Promise.resolve([{ "dataset_id": "master-telemetry", "dataset_config": { "redis_db": 15 } }])
         })
         chai.spy.on(DatasetTransformations, "findAll", () => {
             return Promise.resolve()

--- a/api-service/src/v2/tests/DatasetManagement/DatasetUpdate/Fixtures.ts
+++ b/api-service/src/v2/tests/DatasetManagement/DatasetUpdate/Fixtures.ts
@@ -59,7 +59,7 @@ export const TestInputsForDatasetUpdate = {
                         "values": {
                             "denorm_key": "actor.id",
                             "denorm_out_field": "userdata",
-                            "redis_db": 10
+                            "dataset_id" : "master-telemetry"
                         },
                         "action": "add"
                     }
@@ -298,7 +298,7 @@ export const TestInputsForDatasetUpdate = {
                         "values": {
                             "denorm_key": "actor.id",
                             "denorm_out_field": "userdata",
-                            "redis_db": 10
+                            "dataset_id" : "master-telemetry"
                         },
                         "action": "add"
                     },
@@ -306,7 +306,7 @@ export const TestInputsForDatasetUpdate = {
                         "values": {
                             "denorm_key": "actor.id",
                             "denorm_out_field": "mid",
-                            "redis_db": 10
+                            "dataset_id" : "master-telemetry"
                         },
                         "action": "remove"
                     }
@@ -387,7 +387,7 @@ export const TestInputsForDatasetUpdate = {
                         "values": {
                             "denorm_key": "actor.id",
                             "denorm_out_field": "userdata",
-                            "redis_db": 10
+                            "dataset_id" : "master-telemetry"
                         },
                         "action": "add"
                     },
@@ -395,7 +395,7 @@ export const TestInputsForDatasetUpdate = {
                         "values": {
                             "denorm_key": "actor.id",
                             "denorm_out_field": "userdata",
-                            "redis_db": 10
+                            "dataset_id" : "master-telemetry"
                         },
                         "action": "add"
                     }

--- a/api-service/src/v2/tests/DatasetManagement/DatasetUpdate/Fixtures.ts
+++ b/api-service/src/v2/tests/DatasetManagement/DatasetUpdate/Fixtures.ts
@@ -58,7 +58,8 @@ export const TestInputsForDatasetUpdate = {
                     {
                         "values": {
                             "denorm_key": "actor.id",
-                            "denorm_out_field": "userdata"
+                            "denorm_out_field": "userdata",
+                            "redis_db": 10
                         },
                         "action": "add"
                     }
@@ -93,7 +94,11 @@ export const TestInputsForDatasetUpdate = {
                 {
                     "values": {
                         "field_key": "key1",
-                        "transformation_function": {},
+                        "transformation_function": {
+                            "type": "mask",
+                            "expr": "eid",
+                            "condition": null
+                        },
                         "mode": "Strict",
                         "metadata": {}
                     },
@@ -212,7 +217,11 @@ export const TestInputsForDatasetUpdate = {
                 {
                     "values": {
                         "field_key": "key1",
-                        "transformation_function": {},
+                        "transformation_function": {
+                            "type": "mask",
+                            "expr": "eid",
+                            "condition": null
+                        },
                         "mode": "Strict",
                         "metadata": {}
                     },
@@ -229,7 +238,11 @@ export const TestInputsForDatasetUpdate = {
                 {
                     "values": {
                         "field_key": "key1",
-                        "transformation_function": {},
+                        "transformation_function": {
+                            "type": "mask",
+                            "expr": "eid",
+                            "condition": null
+                        },
                         "mode": "Strict",
                         "metadata": {}
                     },
@@ -284,14 +297,16 @@ export const TestInputsForDatasetUpdate = {
                     {
                         "values": {
                             "denorm_key": "actor.id",
-                            "denorm_out_field": "userdata"
+                            "denorm_out_field": "userdata",
+                            "redis_db": 10
                         },
                         "action": "add"
                     },
                     {
                         "values": {
                             "denorm_key": "actor.id",
-                            "denorm_out_field": "mid"
+                            "denorm_out_field": "mid",
+                            "redis_db": 10
                         },
                         "action": "remove"
                     }
@@ -301,7 +316,11 @@ export const TestInputsForDatasetUpdate = {
                 {
                     "values": {
                         "field_key": "key1",
-                        "transformation_function": {},
+                        "transformation_function": {
+                            "type": "mask",
+                            "expr": "eid",
+                            "condition": null
+                        },
                         "mode": "Strict",
                         "metadata": {}
                     },
@@ -310,7 +329,11 @@ export const TestInputsForDatasetUpdate = {
                 {
                     "values": {
                         "field_key": "key2",
-                        "transformation_function": {},
+                        "transformation_function": {
+                            "type": "mask",
+                            "expr": "eid",
+                            "condition": null
+                        },
                         "mode": "Strict",
                         "metadata": {}
                     },
@@ -319,7 +342,11 @@ export const TestInputsForDatasetUpdate = {
                 {
                     "values": {
                         "field_key": "key3",
-                        "transformation_function": {},
+                        "transformation_function": {
+                            "type": "mask",
+                            "expr": "eid",
+                            "condition": null
+                        },
                         "mode": "Strict",
                         "metadata": {}
                     },
@@ -359,14 +386,16 @@ export const TestInputsForDatasetUpdate = {
                     {
                         "values": {
                             "denorm_key": "actor.id",
-                            "denorm_out_field": "userdata"
+                            "denorm_out_field": "userdata",
+                            "redis_db": 10
                         },
                         "action": "add"
                     },
                     {
                         "values": {
                             "denorm_key": "actor.id",
-                            "denorm_out_field": "userdata"
+                            "denorm_out_field": "userdata",
+                            "redis_db": 10
                         },
                         "action": "add"
                     }
@@ -434,7 +463,11 @@ export const TestInputsForDatasetUpdate = {
                 {
                     "values": {
                         "field_key": "key1",
-                        "transformation_function": {},
+                        "transformation_function": {
+                            "type": "mask",
+                            "expr": "eid",
+                            "condition": null
+                        },
                         "mode": "Strict",
                         "metadata": {}
                     },
@@ -443,7 +476,11 @@ export const TestInputsForDatasetUpdate = {
                 {
                     "values": {
                         "field_key": "key1",
-                        "transformation_function": {},
+                        "transformation_function": {
+                            "type": "mask",
+                            "expr": "eid",
+                            "condition": null
+                        },
                         "mode": "Strict",
                         "metadata": {}
                     },
@@ -452,7 +489,11 @@ export const TestInputsForDatasetUpdate = {
                 {
                     "values": {
                         "field_key": "key2",
-                        "transformation_function": {},
+                        "transformation_function": {
+                            "type": "mask",
+                            "expr": "eid",
+                            "condition": null
+                        },
                         "mode": "Strict",
                         "metadata": {}
                     },
@@ -461,7 +502,11 @@ export const TestInputsForDatasetUpdate = {
                 {
                     "values": {
                         "field_key": "key2",
-                        "transformation_function": {},
+                        "transformation_function": {
+                            "type": "mask",
+                            "expr": "eid",
+                            "condition": null
+                        },
                         "mode": "Strict",
                         "metadata": {}
                     },
@@ -470,7 +515,11 @@ export const TestInputsForDatasetUpdate = {
                 {
                     "values": {
                         "field_key": "key3",
-                        "transformation_function": {},
+                        "transformation_function": {
+                            "type": "mask",
+                            "expr": "eid",
+                            "condition": null
+                        },
                         "mode": "Strict",
                         "metadata": {}
                     },
@@ -479,7 +528,11 @@ export const TestInputsForDatasetUpdate = {
                 {
                     "values": {
                         "field_key": "key3",
-                        "transformation_function": {},
+                        "transformation_function": {
+                            "type": "mask",
+                            "expr": "eid",
+                            "condition": null
+                        },
                         "mode": "Strict",
                         "metadata": {}
                     },


### PR DESCRIPTION
**Description**

1. Generate ingestion spec on status transition from ReadyToPublish to Live
2. Check for version key value for v2 apis only.
3. Ingestion spec generation fixes [transform_spec:{} as required property in ingestion spec]
4. Json Schema for validating transformation configs while create or update dataset.
5. Denorm fields redis_db set internally using dataset_id in the denorm_config.