### PR TITLE
#OBS-I116: Dataset CRUD api fixes

### DIFF
--- a/api-service/src/v2/controllers/DatasetCreate/DatasetCreateValidationSchema.json
+++ b/api-service/src/v2/controllers/DatasetCreate/DatasetCreateValidationSchema.json
@@ -49,8 +49,18 @@
               "default": "Strict"
             }
           },
-          "required": ["validate", "mode"],
-          "additionalProperties": false
+          "required": ["validate"],
+          "additionalProperties": false,
+          "if": {
+            "properties": {
+              "validate": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "required": ["mode"]
+          }
         },
         "extraction_config": {
           "type": "object",
@@ -76,12 +86,37 @@
                   "minLength": 1
                 }
               },
-              "required": ["drop_duplicates", "dedup_key"],
+              "if": {
+                "properties": {
+                  "drop_duplicates": {
+                    "const": true
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "dedup_key": {
+                    "minLength": 1
+                  }
+                },
+                "required": ["dedup_key"]
+              },
+              "required": ["drop_duplicates"],
               "additionalProperties": false
             }
           },
-          "required": ["is_batch_event", "extraction_key", "dedup_config"],
-          "additionalProperties": false
+          "additionalProperties": false,
+          "required": ["is_batch_event"],
+          "if": {
+            "properties": {
+              "is_batch_event": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "required": ["extraction_key", "dedup_config"]
+          }
         },
         "dedup_config": {
           "type": "object",
@@ -95,7 +130,22 @@
               "minLength": 1
             }
           },
-          "required": ["drop_duplicates", "dedup_key"],
+          "if": {
+            "properties": {
+              "drop_duplicates": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "dedup_key": {
+                "minLength": 1
+              }
+            },
+            "required": ["dedup_key"]
+          },
+          "required": ["drop_duplicates"],
           "additionalProperties": false
         },
         "data_schema": {
@@ -297,7 +347,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "minLength":1
+            "minLength": 1
           }
         },
         "sample_data": {

--- a/api-service/src/v2/controllers/DatasetRead/DatasetRead.ts
+++ b/api-service/src/v2/controllers/DatasetRead/DatasetRead.ts
@@ -43,7 +43,7 @@ const datasetRead = async (req: Request, res: Response) => {
 
 const readDraftDataset = async (datasetId: string, attributes: string[]): Promise<any> => {
     
-    const attrs = _.union(attributes, ["dataset_config", "api_version", "type"])
+    const attrs = _.union(attributes, ["dataset_config", "api_version", "type", "id"])
     const draftDataset = await datasetService.getDraftDataset(datasetId, attrs);
     if(draftDataset) { // Contains a draft
         const apiVersion = _.get(draftDataset, ["api_version"]);

--- a/api-service/src/v2/controllers/DatasetStatusTransition/DatasetStatusTransition.ts
+++ b/api-service/src/v2/controllers/DatasetStatusTransition/DatasetStatusTransition.ts
@@ -145,12 +145,14 @@ const validateAndUpdateDenormConfig = async (draftDataset: Record<string, any>) 
                 dataset_id: denormField.dataset_id,
                 exists: (md) ? true : false,
                 isLive:  (md) ? md.status === "Live" : false,
-                status: md.status
+                status: (md) ? md.status : false
             }
-            if(md.api_version === "v2")
-                datasetStatus['denorm_field'] = _.merge(denormField, {redis_db: md.dataset_config.cache_config.redis_db});
-            else 
-                datasetStatus['denorm_field'] = _.merge(denormField, {redis_db: md.dataset_config.redis_db});
+            if(!_.isEmpty(md)){
+                if(md.api_version === "v2")
+                    datasetStatus['denorm_field'] = _.merge(denormField, {redis_db: md.dataset_config.cache_config.redis_db});
+                else 
+                    datasetStatus['denorm_field'] = _.merge(denormField, {redis_db: md.dataset_config.redis_db});
+            }
 
             return datasetStatus;
         })

--- a/api-service/src/v2/controllers/DatasetStatusTransition/DatasetStatusTransition.ts
+++ b/api-service/src/v2/controllers/DatasetStatusTransition/DatasetStatusTransition.ts
@@ -38,11 +38,11 @@ const validateDataset = (dataset: any, datasetId: any, action: string) => {
     }
 
     if (dataset.api_version !== "v2" && _.includes(["ReadyToPublish", "Live"], action)) {
-        throw obsrvError(datasetId, "DATASET_API_VERSION_MISMATCH", "Draft dataset api version is not v2. Perform a read api call with mode=edit to migrate the dataset", "NOT_FOUND", 404)
+        throw obsrvError(datasetId, "DATASET_API_VERSION_MISMATCH", "Draft dataset api version is not v2. Perform a read api call with mode=edit to migrate the dataset", "BAD_REQUEST", 400)
     }
 
     if(!_.includes(allowedTransitions[action], dataset.status)) {
-        throw obsrvError(datasetId, `DATASET_${_.toUpper(action)}_FAILURE`, `Transition failed for dataset: ${dataset.id} status:${dataset.status} with status transition to ${action}`, "NOT_FOUND", 404)
+        throw obsrvError(datasetId, `DATASET_${_.toUpper(action)}_FAILURE`, `Transition failed for dataset: ${dataset.id} status:${dataset.status} with status transition to ${action}`, "CONFLICT", 409)
     }
 
     return true;
@@ -134,7 +134,7 @@ const validateAndUpdateDenormConfig = async (draftDataset: Record<string, any>) 
             throw {
                 code: "SELF_REFERENCING_MASTER_DATA",
                 message: `The denorm master dataset is self-referencing itself`,
-                errCode: "SELF_REFERENCING_MASTER_DATA",
+                errCode: "CONFLICT",
                 statusCode: 409
             }
         }
@@ -162,7 +162,7 @@ const validateAndUpdateDenormConfig = async (draftDataset: Record<string, any>) 
             throw {
                 code: "DEPENDENT_MASTER_DATA_NOT_LIVE",
                 message: `The datasets with id:${invalidIds} are not in published status`,
-                errCode: "DEPENDENT_MASTER_DATA_NOT_LIVE",
+                errCode: "PRECONDITION_REQUIRED",
                 statusCode: 428
             }
         }
@@ -184,7 +184,7 @@ const updateMasterDataConfig = async (draftDataset: Record<string, any>) => {
                 throw {
                     code: "REDIS_DB_INDEX_FETCH_FAILED",
                     message: `Unable to fetch the redis db index for the master data`,
-                    errCode: "REDIS_DB_INDEX_FETCH_FAILED",
+                    errCode: "INTERNAL_SERVER_ERROR",
                     statusCode: 500
                 }
             }

--- a/api-service/src/v2/controllers/DatasetUpdate/DatasetUpdateValidationSchema.json
+++ b/api-service/src/v2/controllers/DatasetUpdate/DatasetUpdateValidationSchema.json
@@ -47,8 +47,18 @@
               "enum": ["Strict", "IgnoreNewFields"]
             }
           },
-          "required": ["validate", "mode"],
-          "additionalProperties": false
+          "required": ["validate"],
+          "additionalProperties": false,
+          "if": {
+            "properties": {
+              "validate": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "required": ["mode"]
+          }
         },
         "extraction_config": {
           "type": "object",
@@ -72,12 +82,37 @@
                   "type": "string"
                 }
               },
-              "required": ["drop_duplicates", "dedup_key"],
+              "if": {
+                "properties": {
+                  "drop_duplicates": {
+                    "const": true
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "dedup_key": {
+                    "minLength": 1
+                  }
+                },
+                "required": ["dedup_key"]
+              },
+              "required": ["drop_duplicates"],
               "additionalProperties": false
             }
           },
-          "required": ["is_batch_event", "extraction_key", "dedup_config"],
-          "additionalProperties": false
+          "additionalProperties": false,
+          "required": ["is_batch_event"],
+          "if": {
+            "properties": {
+              "is_batch_event": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "required": ["extraction_key", "dedup_config"]
+          }
         },
         "dedup_config": {
           "type": "object",
@@ -91,7 +126,22 @@
               "minLength": 1
             }
           },
-          "required": ["drop_duplicates", "dedup_key"],
+          "if": {
+            "properties": {
+              "drop_duplicates": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "dedup_key": {
+                "minLength": 1
+              }
+            },
+            "required": ["dedup_key"]
+          },
+          "required": ["drop_duplicates"],
           "additionalProperties": false
         },
         "data_schema": {

--- a/api-service/src/v2/models/ConnectorInstances.ts
+++ b/api-service/src/v2/models/ConnectorInstances.ts
@@ -49,6 +49,5 @@ export const ConnectorInstances = sequelize.define("connector_instances", {
     tableName: "connector_instances",
     timestamps: true,
     createdAt: "created_date",
-    updatedAt: "updated_date",
-    paranoid: true
+    updatedAt: "updated_date"
 })

--- a/api-service/src/v2/models/ConnectorRegistry.ts
+++ b/api-service/src/v2/models/ConnectorRegistry.ts
@@ -81,6 +81,5 @@ export const ConnectorRegistry = sequelize.define("connector_registry", {
     tableName: "connector_registry",
     timestamps: true,
     createdAt: "created_date",
-    updatedAt: "updated_date",
-    paranoid: true
+    updatedAt: "updated_date"
 })


### PR DESCRIPTION
**Description**:

1. Validation schema changes for Dataset create and update apis.
2. Error code fixes for various error sceanrios
3. Fixes in the check for denorm master dataset to handle empty dataset scenario
4. Using dataset_id from the existing v1 dataset while migration to v2.
5. Using getTransformations method instead of getDraftTransformations while creating Draft dataset out of live v1.
6. Removal of category and datatype attributes while doing a transformation list query while creating Draft dataset out of live v2.
7. Executing publish command after the commit of db queries.
