### PR TITLE
#OBS-I116: fix: Command api and schema fixes

### DIFF
--- a/api-service/src/controllers/DatasetCreate/DatasetCreate.ts
+++ b/api-service/src/controllers/DatasetCreate/DatasetCreate.ts
@@ -69,9 +69,11 @@ const getDatasetConnectors = (connectorConfigs: Array<Record<string, any>>): Arr
         })
         return _.map(uniqueConnectors, (config) => {
             return {
+                id: config.id,
                 connector_id: config.connector_id,
                 connector_config: cipherService.encrypt(JSON.stringify(config.connector_config)),
-                operations_config: config.operations_config
+                operations_config: config.operations_config,
+                version: config.version
             }
         })
     }

--- a/api-service/src/controllers/DatasetCreate/DatasetCreateValidationSchema.json
+++ b/api-service/src/controllers/DatasetCreate/DatasetCreateValidationSchema.json
@@ -71,8 +71,7 @@
             },
             "extraction_key": {
               "type": "string",
-              "default": "events",
-              "minLength": 1
+              "default": "events"
             },
             "dedup_config": {
               "type": "object",
@@ -82,8 +81,7 @@
                   "default": false
                 },
                 "dedup_key": {
-                  "type": "string",
-                  "minLength": 1
+                  "type": "string"
                 }
               },
               "if": {
@@ -115,6 +113,11 @@
             }
           },
           "then": {
+            "properties": {
+              "extraction_key": {
+                "minLength": 1
+              }
+            },
             "required": ["extraction_key", "dedup_config"]
           }
         },
@@ -126,8 +129,7 @@
               "default": true
             },
             "dedup_key": {
-              "type": "string",
-              "minLength": 1
+              "type": "string"
             }
           },
           "if": {

--- a/api-service/src/controllers/DatasetStatusTransition/ReadyToPublishSchema.json
+++ b/api-service/src/controllers/DatasetStatusTransition/ReadyToPublishSchema.json
@@ -376,7 +376,7 @@
             "minLength": 1
           },
           "connector_config": {
-            "type": "object"
+            "type": "string"
           },
           "operations_config": {
             "type": "object"
@@ -402,11 +402,15 @@
     "properties": {
       "dataset_config": {
         "properties": {
-          "data_key": {
-            "minLength": 1
+          "keys_config": {
+            "properties": {
+              "data_key": {
+                "minLength": 1
+              }
+            },
+            "required": ["data_key"]
           }
-        },
-        "required": ["data_key"]
+        }
       }
     }
   },

--- a/api-service/src/controllers/DatasetUpdate/DatasetUpdate.ts
+++ b/api-service/src/controllers/DatasetUpdate/DatasetUpdate.ts
@@ -121,9 +121,11 @@ const mergeConnectorsConfig = (currConfigs: any, newConfigs: any) => {
     return _.unionWith(
         _.map(addConfigs, (config) => {
             return {
+                id: config.id,
                 connector_id: config.connector_id,
                 connector_config: cipherService.encrypt(JSON.stringify(config.connector_config)),
-                operations_config: config.operations_config
+                operations_config: config.operations_config,
+                version: config.version
             }
         }),
         _.reject(currConfigs, (config) => { return _.includes(removeConfigs, config.connector_id)}),

--- a/api-service/src/controllers/DatasetUpdate/DatasetUpdateValidationSchema.json
+++ b/api-service/src/controllers/DatasetUpdate/DatasetUpdateValidationSchema.json
@@ -122,8 +122,7 @@
               "default": true
             },
             "dedup_key": {
-              "type": "string",
-              "minLength": 1
+              "type": "string"
             }
           },
           "if": {

--- a/command-service/src/command/db_command.py
+++ b/command-service/src/command/db_command.py
@@ -171,8 +171,9 @@ class DBCommand(ICommand):
         return result
 
     def _insert_connector_instances(self, dataset_id, draft_dataset_record):
-        emptyJson, result = {}
-        draft_connectors_config_record = draft_dataset_record.connectors_config
+        emptyJson = {}
+        result = {}
+        draft_connectors_config_record = draft_dataset_record.get('connectors_config')
         if draft_connectors_config_record is None:
             return result
         
@@ -190,14 +191,14 @@ class DBCommand(ICommand):
                         '{connector_config.id}',
                         '{dataset_id}',
                         '{connector_config.connector_id}',
-                        '{json.dumps(connector_config.connector_config).replace("'", "''")}',
+                        '{connector_config.connector_config}',
                         '{json.dumps(connector_config.operations_config).replace("'", "''")}',
                         '{connector_config.data_format}',
                         '{DatasetStatusType.Live.name}',
                         '{json.dumps(emptyJson)}',
                         '{json.dumps(emptyJson)}',
-                        '{draft_dataset_record.created_by}',
-                        '{draft_dataset_record.updated_by}',
+                        '{draft_dataset_record.get('created_by')}',
+                        '{draft_dataset_record.get('updated_by')}',
                         '{current_timestamp}',
                         '{current_timestamp}',
                         '{current_timestamp}'
@@ -206,7 +207,7 @@ class DBCommand(ICommand):
                     SET connector_config = '{json.dumps(connector_config.connector_config).replace("'", "''")}',
                     operations_config = '{json.dumps(connector_config.operations_config).replace("'", "''")}',
                     data_format = '{connector_config.data_format}', 
-                    updated_by = '{draft_dataset_record.updated_by}',
+                    updated_by = '{draft_dataset_record.get('updated_by')}',
                     updated_date = '{current_timestamp}',
                     published_date = '{current_timestamp}',
                     status = '{DatasetStatusType.Live.name}';
@@ -225,15 +226,15 @@ class DBCommand(ICommand):
                         '{connector_config.connector_id}',
                         '{json.dumps(connector_config.connector_config).replace("'", "''")}',
                         '{DatasetStatusType.Live.name}',
-                        '{draft_dataset_record.created_by}',
-                        '{draft_dataset_record.updated_by}',
+                        '{draft_dataset_record.get('created_by')}',
+                        '{draft_dataset_record.get('updated_by')}',
                         '{current_timestamp}',
                         '{current_timestamp}',
                         '{current_timestamp}'
                     )
                     ON CONFLICT (id) DO UPDATE
                     SET connector_config = '{json.dumps(connector_config.connector_config).replace("'", "''")}',
-                    updated_by = '{draft_dataset_record.updated_by}',
+                    updated_by = '{draft_dataset_record.get('updated_by')}',
                     updated_date = '{current_timestamp}',
                     published_date = '{current_timestamp}',
                     status = '{DatasetStatusType.Live.name}';
@@ -247,7 +248,7 @@ class DBCommand(ICommand):
 
     def _insert_dataset_transformations(self, dataset_id, draft_dataset_record):
 
-        draft_dataset_transformations_record = draft_dataset_record.transformations_config
+        draft_dataset_transformations_record = draft_dataset_record.get('transformations_config')
         result = {}
         current_timestamp = dt.now()
         # Delete existing transformations
@@ -263,7 +264,7 @@ class DBCommand(ICommand):
             )
             insert_query = f"""
                 INSERT INTO dataset_transformations(id, dataset_id, field_key, transformation_function,
-                status, mode, created_by, updated_by, created_date, updated_date, published_date, metadata)
+                status, mode, created_by, updated_by, created_date, updated_date, published_date)
                 VALUES (
                     '{dataset_id + '_' + transformation.field_key}',
                     '{dataset_id}',
@@ -271,12 +272,11 @@ class DBCommand(ICommand):
                     '{json.dumps(transformation.transformation_function).replace("'", "''")}',
                     '{DatasetStatusType.Live.name}',
                     '{transformation.mode}',
-                    '{transformation.created_by}',
-                    '{transformation.updated_by}',
+                    '{draft_dataset_record.get('created_by')}',
+                    '{draft_dataset_record.get('updated_by')}',
                     '{current_timestamp}',
                     '{current_timestamp}',
-                    '{current_timestamp}',
-                    '{json.dumps(transformation.metadata).replace("'", "''")}'
+                    '{current_timestamp}'
                 )
             """
             result = self.db_service.execute_upsert(insert_query)

--- a/command-service/src/command/db_command.py
+++ b/command-service/src/command/db_command.py
@@ -191,7 +191,7 @@ class DBCommand(ICommand):
                         '{connector_config.id}',
                         '{dataset_id}',
                         '{connector_config.connector_id}',
-                        '{connector_config.connector_config}',
+                        '{json.dumps(connector_config.connector_config).replace("'", "''")}',
                         '{json.dumps(connector_config.operations_config).replace("'", "''")}',
                         '{connector_config.data_format}',
                         '{DatasetStatusType.Live.name}',

--- a/command-service/src/model/db_models.py
+++ b/command-service/src/model/db_models.py
@@ -45,8 +45,8 @@ class DatasetsDraft:
     created_by: str
     created_date: datetime
     sample_data: dict | None = None
-    transformations_config: dict | None = None
-    connectors_config: dict | None = None
+    transformations_config: list[dict] | None = None
+    connectors_config: list[dict] | None = None
     denorm_config: dict | None = None
     tags: list[str] | None = None
     updated_by: str | None = None
@@ -79,7 +79,7 @@ class DatasourcesDraft:
 class DatasetConnectorConfigDraft:
     id: str
     connector_id: str
-    connector_config: dict
+    connector_config: str | None
     version: str
     operations_config: dict | None = None
     data_format: str | None = 'json'


### PR DESCRIPTION
**Description**

1. Adding id and version while saving connectors config.
2. Validation schema fixes for Datasetcreate, update and ReadyToPublish schema 
3. Command api type fixes
4. Command api query fixes