### PR TITLE
#OBS-I77 : query api changes to check datasource availability

### DIFF
--- a/api-service/src/configs/Config.ts
+++ b/api-service/src/configs/Config.ts
@@ -15,7 +15,8 @@ export const config = {
       "sql_query_path": "/druid/v2/sql/",
       "native_query_path": "/druid/v2",
       "list_datasources_path": "/druid/v2/datasources",
-      "submit_ingestion": "druid/indexer/v1/supervisor"
+      "submit_ingestion": "druid/indexer/v1/supervisor",
+      "load_status": "/druid/coordinator/v1/loadstatus"
     },
     "lakehouse": {
       "queryType": "datalake",

--- a/api-service/src/helpers/Datasources.ts
+++ b/api-service/src/helpers/Datasources.ts
@@ -2,7 +2,11 @@ import _ from 'lodash'
 import configDefault from '../resources/schemas/DatasourceConfigDefault.json'
 import { SchemaMerger } from '../generators/SchemaMerger'
 import { DatasetStatus } from '../models/DatasetModels'
+import { config } from "./../configs/Config"
+import constants from "../resources/Constants.json"
+import axios from 'axios'
 let schemaMerger = new SchemaMerger
+const druidHttpService = axios.create({ baseURL: `${config.query_api.druid.host}:${config.query_api.druid.port}`, headers: { "Content-Type": "application/json" } });
 
 export class Datasources {
     private id: string
@@ -60,6 +64,15 @@ export class Datasources {
         return payload
     }
     public getDefaults() {
-        return {...configDefault}
+        return { ...configDefault }
+    }
+    
+    public checkSupervisorAvailability = async (datasourceRef: string) => {
+        const { data } = await druidHttpService.get(config.query_api.druid.load_status);
+        const loadStatus = _.get(data, datasourceRef)
+        if (!(loadStatus && loadStatus === 100)) {
+            console.log(`Datasource ${datasourceRef} is not fuly available to query. Please check the druid datasource.`);
+            throw constants.UNAVAILABLE_DATASOURCE
+        }
     }
 }

--- a/api-service/src/helpers/Datasources.ts
+++ b/api-service/src/helpers/Datasources.ts
@@ -69,8 +69,12 @@ export class Datasources {
     
     public checkSupervisorAvailability = async (datasourceRef: string) => {
         const { data } = await druidHttpService.get(config.query_api.druid.load_status);
-        const loadStatus = _.get(data, datasourceRef)
-        if (!(loadStatus && loadStatus === 100)) {
+        const datasourceAvailaibility = _.get(data, datasourceRef)
+        if (_.isUndefined(datasourceAvailaibility)) {
+            console.log(`Datasource ${datasourceRef} is not available in druid to query.`);
+            throw constants.DATASOURCE_NOT_AVAILABLE
+        }
+        if (datasourceAvailaibility !== 100) {
             console.log(`Datasource ${datasourceRef} is not fuly available to query. Please check the druid datasource.`);
             throw constants.UNAVAILABLE_DATASOURCE
         }

--- a/api-service/src/helpers/Datasources.ts
+++ b/api-service/src/helpers/Datasources.ts
@@ -76,7 +76,7 @@ export class Datasources {
         }
         if (datasourceAvailaibility !== 100) {
             console.log(`Datasource ${datasourceRef} is not fuly available to query. Please check the druid datasource.`);
-            throw constants.UNAVAILABLE_DATASOURCE
+            throw constants.DATASOURCE_NOT_FULLY_AVAILABLE
         }
     }
 }

--- a/api-service/src/helpers/Datasources.ts
+++ b/api-service/src/helpers/Datasources.ts
@@ -69,12 +69,12 @@ export class Datasources {
     
     public checkSupervisorAvailability = async (datasourceRef: string) => {
         const { data } = await druidHttpService.get(config.query_api.druid.load_status);
-        const datasourceAvailaibility = _.get(data, datasourceRef)
-        if (_.isUndefined(datasourceAvailaibility)) {
+        const datasourceAvailability = _.get(data, datasourceRef)
+        if (_.isUndefined(datasourceAvailability)) {
             console.log(`Datasource ${datasourceRef} is not available in druid to query.`);
             throw constants.DATASOURCE_NOT_AVAILABLE
         }
-        if (datasourceAvailaibility !== 100) {
+        if (datasourceAvailability !== 100) {
             console.log(`Datasource ${datasourceRef} is not fuly available to query. Please check the druid datasource.`);
             throw constants.DATASOURCE_NOT_FULLY_AVAILABLE
         }

--- a/api-service/src/resources/Constants.json
+++ b/api-service/src/resources/Constants.json
@@ -31,6 +31,11 @@
     "status": 400,
     "code": "BAD_REQUEST"
   },
+  "UNAVAILABLE_DATASOURCE": {
+    "message": "Datasource is not fully available",
+    "status": 416,
+    "code": "RANGE_NOT_SATISFIABLE"
+  },
   "DATASET_ID_NOT_FOUND": {
     "message": "Dataset Id not found, Failed to ingest",
     "status": 404,

--- a/api-service/src/resources/Constants.json
+++ b/api-service/src/resources/Constants.json
@@ -32,9 +32,14 @@
     "code": "BAD_REQUEST"
   },
   "UNAVAILABLE_DATASOURCE": {
-    "message": "Datasource is not fully available",
+    "message": "Datasource not fully available for querying",
     "status": 416,
     "code": "RANGE_NOT_SATISFIABLE"
+  },
+  "DATASOURCE_NOT_AVAILABLE": {
+    "message": "Datasource is not available for querying",
+    "status": 404,
+    "code": "NOT_FOUND"
   },
   "DATASET_ID_NOT_FOUND": {
     "message": "Dataset Id not found, Failed to ingest",

--- a/api-service/src/resources/Constants.json
+++ b/api-service/src/resources/Constants.json
@@ -31,7 +31,7 @@
     "status": 400,
     "code": "BAD_REQUEST"
   },
-  "UNAVAILABLE_DATASOURCE": {
+  "DATASOURCE_NOT_FULLY_AVAILABLE": {
     "message": "Datasource not fully available for querying",
     "status": 416,
     "code": "RANGE_NOT_SATISFIABLE"

--- a/api-service/src/services/QueryService.ts
+++ b/api-service/src/services/QueryService.ts
@@ -7,12 +7,15 @@ import { IConnector } from "../models/DatasetModels";
 import { ErrorResponseHandler } from "../helpers/ErrorResponseHandler";
 import { updateTelemetryAuditEvent } from "./telemetry";
 import { executeLakehouseQuery } from "../helpers/LakehouseUtil";
+import { Datasources } from "../helpers/Datasources";
+
 
 const telemetryObject = { id: null, type: "datasource", ver: "1.0.0" };
 
 export class QueryService {
   private connector: AxiosInstance;
   private errorHandler: ErrorResponseHandler;
+  private datasourceService = new Datasources({});
   constructor(connector: IConnector) {
     this.connector = connector.connect();
     this.errorHandler = new ErrorResponseHandler("QueryService");
@@ -20,7 +23,9 @@ export class QueryService {
 
   public executeNativeQuery = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      updateTelemetryAuditEvent({ request: req, object: { ...telemetryObject, id: _.get(req, 'body.context.dataSource')} });
+      updateTelemetryAuditEvent({ request: req, object: { ...telemetryObject, id: _.get(req, 'body.context.dataSource') } });
+      const datasource = _.get(req, ["body", "context", "dataSource"])
+      await this.datasourceService.checkSupervisorAvailability(datasource)
       var result = await this.connector.post(config.query_api.druid.native_query_path, req.body.query);
       var mergedResult = result.data;
       if (req.body.query.queryType === "scan" && result.data) {
@@ -36,12 +41,14 @@ export class QueryService {
   public executeSqlQuery = async (req: Request, res: Response, next: NextFunction) => {
     try {
       let result: any = {}
-      updateTelemetryAuditEvent({ request: req, object: { ...telemetryObject, id: _.get(req, 'body.context.dataSource')} });
+      updateTelemetryAuditEvent({ request: req, object: { ...telemetryObject, id: _.get(req, 'body.context.dataSource') } });
       if (req.body?.context?.dataSourceType === config.query_api.lakehouse.queryType) {
         result.data = await executeLakehouseQuery(req.body.querySql.query)
       }
-      else{
-      result = await this.connector.post(config.query_api.druid.sql_query_path, req.body.querySql);
+      else {
+        const datasource = _.get(req, ["body", "context", "dataSource"])
+        await this.datasourceService.checkSupervisorAvailability(datasource)
+        result = await this.connector.post(config.query_api.druid.sql_query_path, req.body.querySql);
       }
       ResponseHandler.successResponse(req, res, { status: result.status || 200, data: result.data });
     } catch (error: any) { this.errorHandler.handleError(req, res, next, error, false); }

--- a/api-service/src/services/QueryService.ts
+++ b/api-service/src/services/QueryService.ts
@@ -47,10 +47,10 @@ export class QueryService {
       }
       else {
         const query = _.get(req, ["body", "querySql", "query"])
-        const regex = /FROM\s+"([^"]+)"/;
+        const regex = /(?<=FROM\s+\")[^\"]+(?=\")/i;
         const source = query.match(regex);
         if (source) {
-          const datasource = source[1];
+          const datasource: string = <string>_.head(source);
           await this.datasourceService.checkSupervisorAvailability(datasource)
         }
         result = await this.connector.post(config.query_api.druid.sql_query_path, req.body.querySql);


### PR DESCRIPTION
### Description
https://sprints.zoho.in/workspace/sanketika#P2/itemdetails/I77

**Query api enhancements**
1. Check for datasource in the druid. If not present then throw error ```{"status":404, "message":"Datasource is not available for quering"}```
2. If datasource in available in the druid but if segments are not fully loaded then throw error ```{"status":416, "message":"Datasource not fully available for quering"}```