### PR TITLE
#OBS-I77 : query api changes to check datasource availability v2

### DIFF
--- a/api-service/src/controllers/DataOut/QueryValidator.ts
+++ b/api-service/src/controllers/DataOut/QueryValidator.ts
@@ -156,7 +156,7 @@ const validateQueryRules = (queryPayload: any, limits: any) => {
         : { message: "Invalid date range! the date range cannot be a null value", statusCode: 400, errCode: "BAD_REQUEST", code: errCode.invalidDateRange };
 };
 
-const getDataSourceRef = async (datasetId: string, srcGranularity?: string) => {
+const getDataSourceRef = async (datasetId: string, requestGranularity?: string) => {
     const dataSources = await getDatasourceList(datasetId)
     if (_.isEmpty(dataSources)) {
         logger.error({ apiId, requestBody, msgid, dataset_id, message: `Datasource ${datasetId} not available in datasource live table`, code: errCode.notFound })
@@ -168,7 +168,7 @@ const getDataSourceRef = async (datasetId: string, srcGranularity?: string) => {
         if (!aggregated) {
             return true;
         }
-        return aggregated && srcGranularity ? granularity === srcGranularity : false;
+        return aggregated && requestGranularity ? granularity === requestGranularity : false;
     });
     return _.get(record, ["dataValues", "datasource_ref"])
 }

--- a/api-service/src/controllers/DataOut/QueryValidator.ts
+++ b/api-service/src/controllers/DataOut/QueryValidator.ts
@@ -16,7 +16,7 @@ let dataset_id: string;
 let requestBody: any;
 let msgid: string;
 const errCode = {
-    notFound: "DATA_OUT_SOURCE_NOT_FOUND",
+    notFound: "DATASOURCE_NOT_FOUND",
     invalidDateRange: "DATA_OUT_INVALID_DATE_RANGE"
 }
 
@@ -175,9 +175,12 @@ const getDataSourceRef = async (datasetId: string, srcGranularity?: string) => {
 
 const checkSupervisorAvailability = async (datasourceRef: string) => {
     const { data } = await druidHttpService.get("/druid/coordinator/v1/loadstatus");
-    const datasourceLoad = _.get(data, datasourceRef)
-    if (!(datasourceLoad && datasourceLoad === 100)) {
-        throw obsrvError("", "DATASOURCE_NOT_AVAILABLE", "Datasource not fully available to query", "RANGE_NOT_SATISFIABLE", 416)
+    const datasourceAvailaibility = _.get(data, datasourceRef)
+    if (_.isUndefined(datasourceAvailaibility)) {
+        throw obsrvError("", "DATASOURCE_NOT_AVAILABLE", "Datasource not available for querying", "NOT_FOUND", 404)
+    }
+    if (datasourceAvailaibility !== 100) {
+        throw obsrvError("", "DATASOURCE_NOT_FULLY_AVAILABLE", "Datasource not fully available for querying", "RANGE_NOT_SATISFIABLE", 416)
     }
 }
 

--- a/api-service/src/controllers/DataOut/QueryValidator.ts
+++ b/api-service/src/controllers/DataOut/QueryValidator.ts
@@ -187,6 +187,9 @@ const checkSupervisorAvailability = async (datasourceRef: string) => {
 const setDatasourceRef = async (datasetId: string, payload: any): Promise<any> => {
     const granularity = _.get(payload, "context.aggregationLevel")
     const datasourceRef = await getDataSourceRef(datasetId, granularity);
+    if (!datasourceRef) {
+        throw obsrvError("", "DATASOURCE_NOT_FOUND", "Datasource not found to query", "NOT_FOUND", 404)
+    }
     await checkSupervisorAvailability(datasourceRef)
     const existingDatasources = await getDatasourceListFromDruid();
 

--- a/api-service/src/controllers/DataOut/QueryValidator.ts
+++ b/api-service/src/controllers/DataOut/QueryValidator.ts
@@ -175,11 +175,11 @@ const getDataSourceRef = async (datasetId: string, srcGranularity?: string) => {
 
 const checkSupervisorAvailability = async (datasourceRef: string) => {
     const { data } = await druidHttpService.get("/druid/coordinator/v1/loadstatus");
-    const datasourceAvailaibility = _.get(data, datasourceRef)
-    if (_.isUndefined(datasourceAvailaibility)) {
+    const datasourceAvailability = _.get(data, datasourceRef)
+    if (_.isUndefined(datasourceAvailability)) {
         throw obsrvError("", "DATASOURCE_NOT_AVAILABLE", "Datasource not available for querying", "NOT_FOUND", 404)
     }
-    if (datasourceAvailaibility !== 100) {
+    if (datasourceAvailability !== 100) {
         throw obsrvError("", "DATASOURCE_NOT_FULLY_AVAILABLE", "Datasource not fully available for querying", "RANGE_NOT_SATISFIABLE", 416)
     }
 }

--- a/api-service/src/controllers/DataOut/QueryValidator.ts
+++ b/api-service/src/controllers/DataOut/QueryValidator.ts
@@ -174,7 +174,7 @@ const getDataSourceRef = async (datasetId: string, srcGranularity?: string) => {
 }
 
 const checkSupervisorAvailability = async (datasourceRef: string) => {
-    const { data } = await druidHttpService.get('/druid/coordinator/v1/loadstatus');
+    const { data } = await druidHttpService.get("/druid/coordinator/v1/loadstatus");
     const datasourceLoad = _.get(data, datasourceRef)
     if (!(datasourceLoad && datasourceLoad === 100)) {
         throw obsrvError("", "DATASOURCE_NOT_AVAILABLE", "Datasource not fully available to query", "RANGE_NOT_SATISFIABLE", 416)

--- a/api-service/src/tests/DatasetManagement/DataOutTest/DataQueryTest.spec.ts
+++ b/api-service/src/tests/DatasetManagement/DataOutTest/DataQueryTest.spec.ts
@@ -7,6 +7,7 @@ import { config } from "../../../configs/Config";
 import chaiSpies from "chai-spies"
 import { describe, it } from "mocha";
 import { Datasource } from "../../../models/Datasource";
+import { druidHttpService } from "../../../connections/druidConnection";
 chai.use(chaiSpies)
 chai.should();
 chai.use(chaiHttp);
@@ -32,6 +33,11 @@ describe("QUERY API TESTS", () => {
             return Promise.resolve(
                 response
             )
+        })
+        chai.spy.on(druidHttpService, "get", () => {
+            return Promise.resolve({
+                data: { "test.1_rollup_week": 100 }
+            })
         })
         nock(druidHost + ":" + druidPort)
             .get(listDruidDatasources)
@@ -74,6 +80,11 @@ describe("QUERY API TESTS", () => {
         chai.spy.on(Datasource, "findAll", () => {
             return Promise.resolve(response)
         })
+        chai.spy.on(druidHttpService, "get", () => {
+            return Promise.resolve({
+                data: { "test.1_rollup_week": 100 }
+            })
+        })
         nock(druidHost + ":" + druidPort)
             .get(listDruidDatasources)
             .reply(200, ["test.1_rollup_week"])
@@ -100,6 +111,11 @@ describe("QUERY API TESTS", () => {
         chai.spy.on(Datasource, "findAll", () => {
             return Promise.resolve(response)
         })
+        chai.spy.on(druidHttpService, "get", () => {
+            return Promise.resolve({
+                data: { "test.1_rollup_week": 100 }
+            })
+        })
         nock(druidHost + ":" + druidPort)
             .get(listDruidDatasources)
             .reply(200, ["test.1_rollup_week"])
@@ -125,6 +141,11 @@ describe("QUERY API TESTS", () => {
     it("Query api success : it should fetch information from druid data source for native query", (done) => {
         chai.spy.on(Datasource, "findAll", () => {
             return Promise.resolve(response)
+        })
+        chai.spy.on(druidHttpService, "get", () => {
+            return Promise.resolve({
+                data: { "test.1_rollup_week": 100 }
+            })
         })
         nock(druidHost + ":" + druidPort)
             .get(listDruidDatasources)
@@ -153,6 +174,11 @@ describe("QUERY API TESTS", () => {
         chai.spy.on(Datasource, "findAll", () => {
             return Promise.resolve(response)
         })
+        chai.spy.on(druidHttpService, "get", () => {
+            return Promise.resolve({
+                data: { "test.1_rollup_week": 100 }
+            })
+        })
         nock(druidHost + ":" + druidPort)
             .get(listDruidDatasources)
             .reply(200, ["test.1_rollup_week"])
@@ -179,6 +205,11 @@ describe("QUERY API TESTS", () => {
     it("Query api success : it should allow druid to query when a valid sql query is given", (done) => {
         chai.spy.on(Datasource, "findAll", () => {
             return Promise.resolve(response)
+        })
+        chai.spy.on(druidHttpService, "get", () => {
+            return Promise.resolve({
+                data: { "test.1_rollup_week": 100 }
+            })
         })
         nock(druidHost + ":" + druidPort)
             .get(listDruidDatasources)
@@ -222,6 +253,11 @@ describe("QUERY API TESTS", () => {
     it("it should set threshold to default when threshold is greater than maximum threshold", (done) => {
         chai.spy.on(Datasource, "findAll", () => {
             return Promise.resolve(response)
+        })
+        chai.spy.on(druidHttpService, "get", () => {
+            return Promise.resolve({
+                data: { "test.1_rollup_week": 100 }
+            })
         })
         nock(druidHost + ":" + druidPort)
             .get(listDruidDatasources)

--- a/api-service/src/tests/DatasetManagement/DataOutTest/DataQueryTest.spec.ts
+++ b/api-service/src/tests/DatasetManagement/DataOutTest/DataQueryTest.spec.ts
@@ -52,7 +52,7 @@ describe("QUERY API TESTS", () => {
                 res.body.params.msgid.should.be.eq(msgid);
                 res.body.responseCode.should.be.eq("NOT_FOUND");
                 res.body.error.message.should.be.eq("Dataset telemetry-events with table week is not available for querying");
-                res.body.error.code.should.be.eq("DATA_OUT_SOURCE_NOT_FOUND");
+                res.body.error.code.should.be.eq("DATASOURCE_NOT_FOUND");
                 done();
             });
     });
@@ -71,7 +71,7 @@ describe("QUERY API TESTS", () => {
                 res.body.responseCode.should.be.eq("NOT_FOUND");
                 res.body.params.msgid.should.be.eq(msgid);
                 res.body.error.message.should.be.eq("Datasource telemetry-events not available for querying");
-                res.body.error.code.should.be.eq("DATA_OUT_SOURCE_NOT_FOUND");
+                res.body.error.code.should.be.eq("DATASOURCE_NOT_FOUND");
                 done();
             });
     });

--- a/api-service/src/tests/QueryTemplates/TemplateQuerying/TemplateQuerying.spec.ts
+++ b/api-service/src/tests/QueryTemplates/TemplateQuerying/TemplateQuerying.spec.ts
@@ -8,6 +8,7 @@ import { Datasource } from "../../../models/Datasource";
 import nock from "nock";
 import { config } from "../../../configs/Config";
 import { templateQueryApiFixtures } from "./Fixtures";
+import { druidHttpService } from "../../../connections/druidConnection";
 const apiId = "api.query.template.query";
 const msgid = "4a7f14c3-d61e-4d4f-be78-181834eeff6d"
 
@@ -50,6 +51,11 @@ describe("QUERY TEMPLATE API", () => {
             return Promise.resolve(response)
         })
 
+        chai.spy.on(druidHttpService, "get", () => {
+            return Promise.resolve({
+                data: { "test.1_rollup_month": 100 }
+            })
+        })
         nock(druidHost + ":" + druidPort)
             .get(listDruidDatasources)
             .reply(200, ["test.1_rollup_month"])
@@ -93,6 +99,11 @@ describe("QUERY TEMPLATE API", () => {
             return Promise.resolve(response)
         })
 
+        chai.spy.on(druidHttpService, "get", () => {
+            return Promise.resolve({
+                data: { "test.1_rollup_month": 100 }
+            })
+        })
         nock(druidHost + ":" + druidPort)
             .get(listDruidDatasources)
             .reply(200, ["test.1_rollup_month"])


### PR DESCRIPTION
### Description
https://sprints.zoho.in/workspace/sanketika#P2/itemdetails/I77

**Query api enhancements**
1. Check for datasource in the druid. If not present then throw error ```{"status":404, "message":"Datasource is not available for quering"}```
2. If datasource in available in the druid but if segments are not fully loaded then throw error ```{"status":416, "message":"Datasource not fully available for quering"}```

**Fix**
1. Support to query all datasources as the api was only supported to query on aggregated datasources.