### PR TITLE
#OBS-I131 : fix: stop deleting draft records if submission tasks fail

### DIFF
--- a/api-service/src/services/DatasetService.ts
+++ b/api-service/src/services/DatasetService.ts
@@ -325,7 +325,7 @@ class DatasetService {
         const draftDatasource = this.createDraftDatasource(draftDataset, "druid");
         const ingestionSpec = tableGenerator.getDruidIngestionSpec(draftDataset, allFields, draftDatasource.datasource_ref);
         _.set(draftDatasource, "ingestion_spec", ingestionSpec)
-        await DatasourceDraft.create(draftDatasource, { transaction })
+        await DatasourceDraft.upsert(draftDatasource, { transaction })
     }
 
     private createHudiDataSource = async (draftDataset: Record<string, any>, transaction: Transaction) => {
@@ -334,7 +334,7 @@ class DatasetService {
         const draftDatasource = this.createDraftDatasource(draftDataset, "hudi");
         const ingestionSpec = tableGenerator.getHudiIngestionSpecForCreate(draftDataset, allFields, draftDatasource.datasource_ref);
         _.set(draftDatasource, "ingestion_spec", ingestionSpec)
-        await DatasourceDraft.create(draftDatasource, { transaction })
+        await DatasourceDraft.upsert(draftDatasource, { transaction })
     }
 
     private updateHudiDataSource = async (draftDataset: Record<string, any>, transaction: Transaction) => {
@@ -345,7 +345,7 @@ class DatasetService {
         const liveDatasource = await Datasource.findOne({ where: { id: dsId }, attributes: ["ingestion_spec"], raw: true }) as unknown as Record<string, any>
         const ingestionSpec = tableGenerator.getHudiIngestionSpecForUpdate(draftDataset, liveDatasource?.ingestion_spec, allFields, draftDatasource?.datasource_ref);
         _.set(draftDatasource, "ingestion_spec", ingestionSpec)
-        await DatasourceDraft.create(draftDatasource, { transaction })
+        await DatasourceDraft.upsert(draftDatasource, { transaction })
     }
 
     private createDraftDatasource = (draftDataset: Record<string, any>, type: string): Record<string, any> => {

--- a/api-service/src/tests/DatasetManagement/DatasetStatusTransition/DatasetLive.spec.ts
+++ b/api-service/src/tests/DatasetManagement/DatasetStatusTransition/DatasetLive.spec.ts
@@ -38,7 +38,7 @@ describe("DATASET STATUS TRANSITION LIVE", () => {
         chai.spy.on(Dataset, "findOne", () => {
             return Promise.resolve({ "data_schema": { "email": { "data_type": "string", "arrival_format": "string" } } })
         })
-        chai.spy.on(DatasourceDraft, "create", () => {
+        chai.spy.on(DatasourceDraft, "upsert", () => {
             return Promise.resolve({})
         })
         const t = chai.spy.on(sequelize, "transaction", () => {
@@ -80,7 +80,7 @@ describe("DATASET STATUS TRANSITION LIVE", () => {
         chai.spy.on(Dataset, "findOne", () => {
             return Promise.resolve({ "data_schema": { "email": { "data_type": "string", "arrival_format": "string" } } })
         })
-        chai.spy.on(DatasourceDraft, "create", () => {
+        chai.spy.on(DatasourceDraft, "upsert", () => {
             return Promise.resolve({})
         })
         const t = chai.spy.on(sequelize, "transaction", () => {
@@ -122,7 +122,7 @@ describe("DATASET STATUS TRANSITION LIVE", () => {
         chai.spy.on(Dataset, "findOne", () => {
             return Promise.resolve({ "api_version":"v2", "data_schema": { "email": { "data_type": "string", "arrival_format": "string" } } })
         })
-        chai.spy.on(DatasourceDraft, "create", () => {
+        chai.spy.on(DatasourceDraft, "upsert", () => {
             return Promise.resolve({})
         })
         chai.spy.on(Datasource, "findOne", () => {
@@ -289,7 +289,7 @@ describe("DATASET STATUS TRANSITION LIVE", () => {
         chai.spy.on(Dataset, "findOne", () => {
             return Promise.resolve({ "data_schema": { "email": { "data_type": "string", "arrival_format": "string" } } })
         })
-        chai.spy.on(DatasourceDraft, "create", () => {
+        chai.spy.on(DatasourceDraft, "upsert", () => {
             return Promise.resolve({})
         })
         const t = chai.spy.on(sequelize, "transaction", () => {

--- a/command-service/src/command/db_command.py
+++ b/command-service/src/command/db_command.py
@@ -48,7 +48,6 @@ class DBCommand(ICommand):
             self._insert_datasource_record(dataset_id, draft_dataset_id)
             self._insert_connector_instances(dataset_id, draft_dataset_record)
             self._insert_dataset_transformations(dataset_id, draft_dataset_record)
-            self._delete_draft_dataset(dataset_id, draft_dataset_id)
             return ActionResponse(status="OK", status_code=200)
         else:
             return ActionResponse(
@@ -413,17 +412,3 @@ class DBCommand(ICommand):
             result = self.db_service.execute_upsert(sql=insert_query, params=params)
             print(f"Dataset Transformation {dataset_id + '_' + transformation.field_key} record inserted successfully...")
         return result
-    
-    def _delete_draft_dataset(self, dataset_id, draft_dataset_id):
-
-        self.db_service.execute_delete(sql=f"""DELETE from datasources_draft where dataset_id = %s""", params=(draft_dataset_id,))
-        print(f"Draft datasources/tables for {dataset_id} are deleted successfully...")
-
-        self.db_service.execute_delete(sql=f"""DELETE from dataset_transformations_draft where dataset_id = %s""", params=(draft_dataset_id,))
-        print(f"Draft transformations/tables for {dataset_id} are deleted successfully...")
-
-        self.db_service.execute_delete(sql=f"""DELETE from dataset_source_config_draft where dataset_id = %s""", params=(draft_dataset_id,))
-        print(f"Draft source config/tables for {dataset_id} are deleted successfully...")
-
-        self.db_service.execute_delete(sql=f"""DELETE from datasets_draft where id = %s""", params=(draft_dataset_id,))
-        print(f"Draft Dataset for {dataset_id} is deleted successfully...")

--- a/command-service/src/config/service_config.yml
+++ b/command-service/src/config/service_config.yml
@@ -117,7 +117,7 @@ config_service:
   port: 4000
 
 druid:
-  router_host: localhost
+  router_host: http://localhost
   router_port: 8888
   supervisor_endpoint: indexer/v1/supervisor
 


### PR DESCRIPTION
### Description
https://sprints.zoho.in/workspace/sanketika#P2/itemdetails/I131

**Publish api changes**
1. Stop deleting dataset records in MAKE_DATASET_LIVE command.
2. Only on successful submission of ingestion task, delete the dataset draft records.
3. Do a datasource upsert during status transition to Live.