### PR TITLE
#OBS-I357: fix: updated connector command

### DIFF
--- a/command-service/src/command/connector_command.py
+++ b/command-service/src/command/connector_command.py
@@ -284,6 +284,9 @@ class ConnectorCommand(ICommand):
         records = self.db_service.execute_select_all(sql=query, params=params)
 
         for record in records:
+            if isinstance(record["connector_source"], str):
+                record["connector_source"] = json.loads(record["connector_source"])
+            
             active_connectors.append(from_dict(
                 data_class=ConnectorInstance, data=record
             ))


### PR DESCRIPTION
When a dataset is published with connector, it expects connector_source to be a dictionary but it arrives as a string.
This fix: parses the string and stores as a dictionary