### PR TITLE
#OBS-I408: data schema fix for proper mappings and data type suggestions

### DIFF
--- a/api-service/src/services/SchemaGenerateService/SchemaHandler.ts
+++ b/api-service/src/services/SchemaGenerateService/SchemaHandler.ts
@@ -43,8 +43,11 @@ export class SchemaHandler {
         return _.set(schema, `${absolutePath}`, {
             ...schema[absolutePath],
             ...{
-                type: resolution.value,
-                oneof: conflict.schema.values.map(key => ({ type: key })),
+                type: resolution.value || _.first(conflict.schema.values),
+                oneof: conflict.schema.values.map(key => {
+                    const storeFormat = _.get(dataMappingPaths, key);
+                    return { type: _.get(DataMappings, storeFormat) }
+                }),
             }
         });
     }
@@ -89,12 +92,13 @@ export class SchemaHandler {
     }
 
     private getArrivalFormat(schema: any, fieldData: any, property: any, type: string) {
-        const types = _.get(fieldData, type);
-        types && types.map((item: any) => {
-            const storeFormat = _.get(dataMappingPaths, item.type);
+        const types = _.get(fieldData, type)
+        const propType = _.get(fieldData, "type")
+        if(types){
+            const storeFormat = _.get(dataMappingPaths, propType);
             _.set(schema, `${property}.arrival_format`, _.first(storeFormat.split(".")));
             _.set(schema, `${property}.data_type`, _.get(DataMappings, storeFormat));
-        })
+        }
         return;
     }
 

--- a/api-service/src/services/SchemaGenerateService/SchemaMapping.json
+++ b/api-service/src/services/SchemaGenerateService/SchemaMapping.json
@@ -48,7 +48,7 @@
                 "datasource": "long"
             },
             "float": {
-                "jsonSchema": "number",
+                "jsonSchema": "float",
                 "datasource": "double"
             },
             "long": {
@@ -56,7 +56,7 @@
                 "datasource": "long"
             },
             "double": {
-                "jsonSchema": "number",
+                "jsonSchema": "double",
                 "datasource": "double"
             },
             "bigdecimal": {
@@ -66,6 +66,10 @@
             "epoch":{
                 "jsonSchema": "integer",
                 "datasource": "long"
+            },
+            "number":{
+                "jsonSchema": "double",
+                "datasource": "double"
             }
         }
     },


### PR DESCRIPTION
**Description:**

1. Updating the oneof by mapping the arrival format conflicts values to data type values.
2. Fetching the storeformat based on type of the property instead of mapping the oneof.
3. Updated schema mappings based on updated mappings.
4. Updating the conflicts suggestions by mapping the arrival format conflict values to data type values.