### PR TITLE
fix: #OBS-I452 Dataset in/out apis updated for dataset check using alias

### DIFF
--- a/api-service/src/controllers/DataIngestion/DataIngestionController.ts
+++ b/api-service/src/controllers/DataIngestion/DataIngestionController.ts
@@ -7,14 +7,9 @@ import { send } from "../../connections/kafkaConnection";
 import { datasetService } from "../../services/DatasetService";
 import logger from "../../logger";
 import { config } from "../../configs/Config";
+import { obsrvError } from "../../types/ObsrvError";
 
 const errorObject = {
-    datasetNotFound: {
-        "message": "Dataset with id not found",
-        "statusCode": 404,
-        "errCode": "BAD_REQUEST",
-        "code": "DATASET_NOT_FOUND"
-    },
     topicNotFound: {
         "message": "Entry topic is not defined",
         "statusCode": 404,
@@ -24,29 +19,35 @@ const errorObject = {
 }
 const apiId = "api.data.in";
 
+const requestValidation = async (req: Request) => {
+    const datasetKey = req.params.dataset_id.trim();
+
+    const isValidSchema = schemaValidation(req.body, validationSchema)
+    if (!isValidSchema?.isValid) {
+        throw obsrvError("", "DATA_INGESTION_INVALID_INPUT", isValidSchema?.message, "BAD_REQUEST", 400)
+    }
+    let dataset = await datasetService.getDatasetWithAlias(datasetKey, ["id", "entry_topic", "api_version", "dataset_config", "dataset_id", "extraction_config"], true) //dataset check considering datakey as alias name
+    if (_.isEmpty(dataset)) {
+        logger.info({ apiId, message: `Dataset with alias '${datasetKey}' does not exist` })
+        dataset = await datasetService.getDataset(datasetKey, ["id", "entry_topic", "api_version", "dataset_config", "dataset_id", "extraction_config"], true) //dataset check considering datakey as dataset_id
+        if (_.isEmpty(dataset)) {
+            throw obsrvError(datasetKey, "DATASET_NOT_FOUND", `Dataset with id/alias name '${datasetKey}' not found`, "NOT_FOUND", 404)
+        }
+    }
+    return dataset
+}
+
 const dataIn = async (req: Request, res: Response) => {
 
-    const requestBody = req.body;
-        const datasetId = req.params.dataset_id.trim();
-
-        const isValidSchema = schemaValidation(requestBody, validationSchema)
-        if (!isValidSchema?.isValid) {
-            logger.error({ apiId, message: isValidSchema?.message, code: "DATA_INGESTION_INVALID_INPUT" })
-            return ResponseHandler.errorResponse({ message: isValidSchema?.message, statusCode: 400, errCode: "BAD_REQUEST", code: "DATA_INGESTION_INVALID_INPUT" }, req, res);
-        }
-        const dataset = await datasetService.getDataset(datasetId, ["id", "entry_topic", "api_version", "dataset_config"], true)
-        if (!dataset) {
-            logger.error({ apiId, message: `Dataset with id ${datasetId} not found in live table`, code: "DATASET_NOT_FOUND" })
-            return ResponseHandler.errorResponse(errorObject.datasetNotFound, req, res);
-        }
-        const { entry_topic, dataset_config, extraction_config, api_version } = dataset
-        const entryTopic = api_version !== "v2" ? _.get(dataset_config, "entry_topic") : entry_topic
-        if (!entryTopic) {
-            logger.error({ apiId, message: "Entry topic not found", code: "TOPIC_NOT_FOUND" })
-            return ResponseHandler.errorResponse(errorObject.topicNotFound, req, res);
-        }
-        await send(addMetadataToEvents(datasetId, requestBody, extraction_config), entryTopic)
-        ResponseHandler.successResponse(req, res, { status: 200, data: { message: "Data ingested successfully" } });
+    const dataset = await requestValidation(req)
+    const { entry_topic, dataset_config, extraction_config, api_version, dataset_id } = dataset
+    const entryTopic = api_version !== "v2" ? _.get(dataset_config, "entry_topic") : entry_topic
+    if (!entryTopic) {
+        logger.error({ apiId, message: "Entry topic not found", code: "TOPIC_NOT_FOUND" })
+        return ResponseHandler.errorResponse(errorObject.topicNotFound, req, res);
+    }
+    await send(addMetadataToEvents(dataset_id, req.body, extraction_config), entryTopic)
+    ResponseHandler.successResponse(req, res, { status: 200, data: { message: "Data ingested successfully" } });
 
 }
 
@@ -59,14 +60,14 @@ const addMetadataToEvents = (datasetId: string, payload: any, extraction_config:
     if (Array.isArray(validData)) {
         const extraction_key: string = _.get(extraction_config, "extraction_key", 'events');
         const dedup_key: string = _.get(extraction_config, "dedup_config.dedup_key", 'id');
-            const payload: any = {
-                "obsrv_meta": obsrvMeta,
-                "dataset": datasetId,
-                "msgid": mid
-            };
-            payload[extraction_key] = validData;
-            payload[dedup_key] = mid
-            return payload;
+        const payload: any = {
+            "obsrv_meta": obsrvMeta,
+            "dataset": datasetId,
+            "msgid": mid
+        };
+        payload[extraction_key] = validData;
+        payload[dedup_key] = mid
+        return payload;
     }
     else {
         return ({

--- a/api-service/src/controllers/DataIngestion/DataIngestionController.ts
+++ b/api-service/src/controllers/DataIngestion/DataIngestionController.ts
@@ -21,7 +21,7 @@ const requestValidation = async (req: Request) => {
     let dataset = await datasetService.getDatasetWithAlias(datasetKey, ["id", "entry_topic", "api_version", "dataset_config", "dataset_id", "extraction_config"], true) //dataset check considering datasetKey as alias name
     if (_.isEmpty(dataset)) {
         logger.info({ apiId, message: `Dataset with alias '${datasetKey}' does not exist` })
-        dataset = await datasetService.getDataset(datasetKey, ["id", "entry_topic", "api_version", "dataset_config", "dataset_id", "extraction_config"], true) //dataset check considering datasetKey as dataset_id
+        dataset = await datasetService.getLiveDataset(datasetKey, ["id", "entry_topic", "api_version", "dataset_config", "dataset_id", "extraction_config"], true) //dataset check considering datasetKey as dataset_id
         if (_.isEmpty(dataset)) {
             throw obsrvError(datasetKey, "DATASET_NOT_FOUND", `Dataset with id/alias name '${datasetKey}' not found`, "NOT_FOUND", 404)
         }

--- a/api-service/src/controllers/DataIngestion/DataIngestionController.ts
+++ b/api-service/src/controllers/DataIngestion/DataIngestionController.ts
@@ -9,14 +9,6 @@ import logger from "../../logger";
 import { config } from "../../configs/Config";
 import { obsrvError } from "../../types/ObsrvError";
 
-const errorObject = {
-    topicNotFound: {
-        "message": "Entry topic is not defined",
-        "statusCode": 404,
-        "errCode": "BAD_REQUEST",
-        "code": "TOPIC_NOT_FOUND"
-    }
-}
 const apiId = "api.data.in";
 
 const requestValidation = async (req: Request) => {
@@ -43,8 +35,7 @@ const dataIn = async (req: Request, res: Response) => {
     const { entry_topic, dataset_config, extraction_config, api_version, dataset_id } = dataset
     const entryTopic = api_version !== "v2" ? _.get(dataset_config, "entry_topic") : entry_topic
     if (!entryTopic) {
-        logger.error({ apiId, message: "Entry topic not found", code: "TOPIC_NOT_FOUND" })
-        return ResponseHandler.errorResponse(errorObject.topicNotFound, req, res);
+        throw obsrvError(dataset_id, "TOPIC_NOT_FOUND", `Entry topic not found`, "NOT_FOUND", 404)
     }
     await send(addMetadataToEvents(dataset_id, req.body, extraction_config), entryTopic)
     ResponseHandler.successResponse(req, res, { status: 200, data: { message: "Data ingested successfully" } });

--- a/api-service/src/controllers/DataIngestion/DataIngestionController.ts
+++ b/api-service/src/controllers/DataIngestion/DataIngestionController.ts
@@ -18,10 +18,10 @@ const requestValidation = async (req: Request) => {
     if (!isValidSchema?.isValid) {
         throw obsrvError("", "DATA_INGESTION_INVALID_INPUT", isValidSchema?.message, "BAD_REQUEST", 400)
     }
-    let dataset = await datasetService.getDatasetWithAlias(datasetKey, ["id", "entry_topic", "api_version", "dataset_config", "dataset_id", "extraction_config"], true) //dataset check considering datakey as alias name
+    let dataset = await datasetService.getDatasetWithAlias(datasetKey, ["id", "entry_topic", "api_version", "dataset_config", "dataset_id", "extraction_config"], true) //dataset check considering datasetKey as alias name
     if (_.isEmpty(dataset)) {
         logger.info({ apiId, message: `Dataset with alias '${datasetKey}' does not exist` })
-        dataset = await datasetService.getDataset(datasetKey, ["id", "entry_topic", "api_version", "dataset_config", "dataset_id", "extraction_config"], true) //dataset check considering datakey as dataset_id
+        dataset = await datasetService.getDataset(datasetKey, ["id", "entry_topic", "api_version", "dataset_config", "dataset_id", "extraction_config"], true) //dataset check considering datasetKey as dataset_id
         if (_.isEmpty(dataset)) {
             throw obsrvError(datasetKey, "DATASET_NOT_FOUND", `Dataset with id/alias name '${datasetKey}' not found`, "NOT_FOUND", 404)
         }

--- a/api-service/src/controllers/DataIngestion/DataIngestionController.ts
+++ b/api-service/src/controllers/DataIngestion/DataIngestionController.ts
@@ -5,7 +5,6 @@ import { schemaValidation } from "../../services/ValidationService";
 import { ResponseHandler } from "../../helpers/ResponseHandler";
 import { send } from "../../connections/kafkaConnection";
 import { datasetService } from "../../services/DatasetService";
-import logger from "../../logger";
 import { config } from "../../configs/Config";
 import { obsrvError } from "../../types/ObsrvError";
 
@@ -18,13 +17,9 @@ const requestValidation = async (req: Request) => {
     if (!isValidSchema?.isValid) {
         throw obsrvError("", "DATA_INGESTION_INVALID_INPUT", isValidSchema?.message, "BAD_REQUEST", 400)
     }
-    let dataset = await datasetService.getDatasetWithAlias(datasetKey, ["id", "entry_topic", "api_version", "dataset_config", "dataset_id", "extraction_config"], true) //dataset check considering datasetKey as alias name
+    const dataset = await datasetService.getDatasetWithDatasetkey(datasetKey, ["id", "entry_topic", "api_version", "dataset_config", "dataset_id", "extraction_config"], true)
     if (_.isEmpty(dataset)) {
-        logger.info({ apiId, message: `Dataset with alias '${datasetKey}' does not exist` })
-        dataset = await datasetService.getLiveDataset(datasetKey, ["id", "entry_topic", "api_version", "dataset_config", "dataset_id", "extraction_config"], true) //dataset check considering datasetKey as dataset_id
-        if (_.isEmpty(dataset)) {
-            throw obsrvError(datasetKey, "DATASET_NOT_FOUND", `Dataset with id/alias name '${datasetKey}' not found`, "NOT_FOUND", 404)
-        }
+        throw obsrvError(datasetKey, "DATASET_NOT_FOUND", `Dataset with id/alias name '${datasetKey}' not found`, "NOT_FOUND", 404)
     }
     return dataset
 }

--- a/api-service/src/controllers/DataOut/DataOutController.ts
+++ b/api-service/src/controllers/DataOut/DataOutController.ts
@@ -6,17 +6,33 @@ import validationSchema from "./DataOutValidationSchema.json";
 import { validateQuery } from "./QueryValidator";
 import * as _ from "lodash";
 import { executeNativeQuery, executeSqlQuery } from "../../connections/druidConnection";
+import { datasetService } from "../../services/DatasetService";
+import { obsrvError } from "../../types/ObsrvError";
 
 export const apiId = "api.data.out";
+
+const requestValidation = async (req: Request) => {
+    const datasetKey = req.params?.dataset_id;
+    const isValidSchema = schemaValidation(req.body, validationSchema);
+    if (!isValidSchema?.isValid) {
+        throw obsrvError(datasetKey, "DATA_OUT_INVALID_INPUT", isValidSchema?.message, "BAD_REQUEST", 400)
+    }
+    let dataset = await datasetService.getDatasetWithAlias(datasetKey, ["dataset_id"], true) //dataset check considering datakey as alias name
+    if (_.isEmpty(dataset)) {
+        logger.info({ apiId, message: `Dataset with alias '${datasetKey}' does not exist` })
+        dataset = await datasetService.getDataset(datasetKey, ["dataset_id"], true) //dataset check considering datakey as dataset_id
+        if (_.isEmpty(dataset)) {
+            throw obsrvError(datasetKey, "DATASET_NOT_FOUND", `Dataset with id/alias name '${datasetKey}' not found`, "NOT_FOUND", 404)
+        }
+    }
+    return dataset
+}
+
 const dataOut = async (req: Request, res: Response) => {
-    const datasetId = req.params?.dataset_id;
     const requestBody = req.body;
     const msgid = _.get(req, "body.params.msgid");
-    const isValidSchema = schemaValidation(requestBody, validationSchema);
-    if (!isValidSchema?.isValid) {
-        logger.error({ apiId, datasetId, msgid, requestBody, message: isValidSchema?.message, code: "DATA_OUT_INVALID_INPUT" })
-        return ResponseHandler.errorResponse({ message: isValidSchema?.message, statusCode: 400, errCode: "BAD_REQUEST", code: "DATA_OUT_INVALID_INPUT" }, req, res);
-    }
+    const dataset = await requestValidation(req)
+    const datasetId = _.get(dataset, "dataset_id")
     const isValidQuery: any = await validateQuery(req.body, datasetId);
     const query = _.get(req, "body.query", "")
 

--- a/api-service/src/controllers/DataOut/DataOutController.ts
+++ b/api-service/src/controllers/DataOut/DataOutController.ts
@@ -20,7 +20,7 @@ const requestValidation = async (req: Request) => {
     let dataset = await datasetService.getDatasetWithAlias(datasetKey, ["dataset_id"], true) //dataset check considering datasetKey as alias name
     if (_.isEmpty(dataset)) {
         logger.info({ apiId, message: `Dataset with alias '${datasetKey}' does not exist` })
-        dataset = await datasetService.getDataset(datasetKey, ["dataset_id"], true) //dataset check considering datasetKey as dataset_id
+        dataset = await datasetService.getLiveDataset(datasetKey, ["dataset_id"], true) //dataset check considering datasetKey as dataset_id
         if (_.isEmpty(dataset)) {
             throw obsrvError(datasetKey, "DATASET_NOT_FOUND", `Dataset with id/alias name '${datasetKey}' not found`, "NOT_FOUND", 404)
         }

--- a/api-service/src/controllers/DataOut/DataOutController.ts
+++ b/api-service/src/controllers/DataOut/DataOutController.ts
@@ -17,13 +17,9 @@ const requestValidation = async (req: Request) => {
     if (!isValidSchema?.isValid) {
         throw obsrvError(datasetKey, "DATA_OUT_INVALID_INPUT", isValidSchema?.message, "BAD_REQUEST", 400)
     }
-    let dataset = await datasetService.getDatasetWithAlias(datasetKey, ["dataset_id"], true) //dataset check considering datasetKey as alias name
+    const dataset = await datasetService.getDatasetWithDatasetkey(datasetKey, ["dataset_id"], true)
     if (_.isEmpty(dataset)) {
-        logger.info({ apiId, message: `Dataset with alias '${datasetKey}' does not exist` })
-        dataset = await datasetService.getLiveDataset(datasetKey, ["dataset_id"], true) //dataset check considering datasetKey as dataset_id
-        if (_.isEmpty(dataset)) {
-            throw obsrvError(datasetKey, "DATASET_NOT_FOUND", `Dataset with id/alias name '${datasetKey}' not found`, "NOT_FOUND", 404)
-        }
+        throw obsrvError(datasetKey, "DATASET_NOT_FOUND", `Dataset with id/alias name '${datasetKey}' not found`, "NOT_FOUND", 404)
     }
     return dataset
 }

--- a/api-service/src/controllers/DataOut/DataOutController.ts
+++ b/api-service/src/controllers/DataOut/DataOutController.ts
@@ -17,10 +17,10 @@ const requestValidation = async (req: Request) => {
     if (!isValidSchema?.isValid) {
         throw obsrvError(datasetKey, "DATA_OUT_INVALID_INPUT", isValidSchema?.message, "BAD_REQUEST", 400)
     }
-    let dataset = await datasetService.getDatasetWithAlias(datasetKey, ["dataset_id"], true) //dataset check considering datakey as alias name
+    let dataset = await datasetService.getDatasetWithAlias(datasetKey, ["dataset_id"], true) //dataset check considering datasetKey as alias name
     if (_.isEmpty(dataset)) {
         logger.info({ apiId, message: `Dataset with alias '${datasetKey}' does not exist` })
-        dataset = await datasetService.getDataset(datasetKey, ["dataset_id"], true) //dataset check considering datakey as dataset_id
+        dataset = await datasetService.getDataset(datasetKey, ["dataset_id"], true) //dataset check considering datasetKey as dataset_id
         if (_.isEmpty(dataset)) {
             throw obsrvError(datasetKey, "DATASET_NOT_FOUND", `Dataset with id/alias name '${datasetKey}' not found`, "NOT_FOUND", 404)
         }

--- a/api-service/src/controllers/DataOut/QueryValidator.ts
+++ b/api-service/src/controllers/DataOut/QueryValidator.ts
@@ -117,7 +117,7 @@ const setQueryLimits = (queryPayload: any) => {
 
 const getDataSourceFromPayload = (queryPayload: any) => {
     if (_.isString(queryPayload.query)) {
-        queryPayload?.query.replace(/from\s+["'`]?[\w-]+["'`]?(\s+where\s+)/i, ` from "${dataset_id}"$1`);
+        queryPayload.query = queryPayload.query.replace(/from\s+["'`]?[\w-]+["'`]?(\s+where\s+)/i, ` from "${dataset_id}"$1`);
         return dataset_id
     }
     if (_.isObject(queryPayload.query)) {

--- a/api-service/src/services/DatasetService.ts
+++ b/api-service/src/services/DatasetService.ts
@@ -26,8 +26,12 @@ class DatasetService {
         return Dataset.findOne({ where: { id: datasetId }, attributes, raw: raw });
     }
 
+    getLiveDataset = async (datasetId: string, attributes?: string[], raw = false): Promise<any> => {
+        return Dataset.findOne({ where: { id: datasetId, status: DatasetStatus.Live }, attributes, raw: raw });
+    }
+
     getDatasetWithAlias = async (alias: string, attributes?: string[], raw = false): Promise<any> => {
-        return Dataset.findOne({ where: { alias }, attributes, raw: raw });
+        return Dataset.findOne({ where: { alias, status: DatasetStatus.Live }, attributes, raw: raw });
     }
 
     findDatasets = async (where?: Record<string, any>, attributes?: string[], order?: any): Promise<any> => {

--- a/api-service/src/services/DatasetService.ts
+++ b/api-service/src/services/DatasetService.ts
@@ -19,6 +19,7 @@ import { druidHttpService } from "../connections/druidConnection";
 import { tableGenerator } from "./TableGenerator";
 import { deleteAlertByDataset, deleteMetricAliasByDataset } from "./managers";
 import { config } from "../configs/Config";
+import { Op } from "sequelize";
 
 class DatasetService {
 
@@ -26,12 +27,15 @@ class DatasetService {
         return Dataset.findOne({ where: { id: datasetId }, attributes, raw: raw });
     }
 
-    getLiveDataset = async (datasetId: string, attributes?: string[], raw = false): Promise<any> => {
-        return Dataset.findOne({ where: { id: datasetId, status: DatasetStatus.Live }, attributes, raw: raw });
-    }
-
-    getDatasetWithAlias = async (alias: string, attributes?: string[], raw = false): Promise<any> => {
-        return Dataset.findOne({ where: { alias, status: DatasetStatus.Live }, attributes, raw: raw });
+    getDatasetWithDatasetkey = async (datasetKey: string, attributes?: string[], raw = false): Promise<any> => {
+        return Dataset.findOne({
+            where: {
+                [Op.and]: [
+                    { [Op.or]: [{ dataset_id: datasetKey }, { alias: datasetKey }] },
+                    { status: DatasetStatus.Live }
+                ]
+            }, attributes, raw: raw
+        });
     }
 
     findDatasets = async (where?: Record<string, any>, attributes?: string[], order?: any): Promise<any> => {

--- a/api-service/src/services/DatasetService.ts
+++ b/api-service/src/services/DatasetService.ts
@@ -26,6 +26,10 @@ class DatasetService {
         return Dataset.findOne({ where: { id: datasetId }, attributes, raw: raw });
     }
 
+    getDatasetWithAlias = async (alias: string, attributes?: string[], raw = false): Promise<any> => {
+        return Dataset.findOne({ where: { alias }, attributes, raw: raw });
+    }
+
     findDatasets = async (where?: Record<string, any>, attributes?: string[], order?: any): Promise<any> => {
         return Dataset.findAll({ where, attributes, order, raw: true })
     }


### PR DESCRIPTION
**Description:**

- Data in api: Try to fetch dataset using dataset alias name, if found get the dataset_id from it and continue. If not found the try to fetch from dataset_id. If not found for both, then throw not found error.
- Data out api: Try to fetch dataset using dataset alias name, if found get the dataset_id from it and continue. If not found the try to fetch from dataset_id. If not found for both, then throw not found error.

Fixed bug: The query was not updating as the given string was not getting replaced with dataset_id using regex in the sql query validation.
