### PR TITLE
feat #OBS-I558 : Do a datasource update if already exists in v1

### DIFF
--- a/api-service/src/controllers/DatasetStatusTransition/ReadyToPublishSchema.json
+++ b/api-service/src/controllers/DatasetStatusTransition/ReadyToPublishSchema.json
@@ -342,6 +342,38 @@
           "additionalProperties": false
         }
       },
+      "if": {
+        "properties": {
+          "indexing_config": {
+            "type": "object",
+            "anyOf": [
+              {
+                "properties": {
+                  "lakehouse_enabled": {
+                    "const": true
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "cache_enabled": {
+                    "const": true
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "keys_config": {
+            "required": [
+              "data_key"
+            ]
+          }
+        }
+      },
       "required": [
         "indexing_config",
         "keys_config",

--- a/api-service/src/controllers/DatasetStatusTransition/ReadyToPublishSchema.json
+++ b/api-service/src/controllers/DatasetStatusTransition/ReadyToPublishSchema.json
@@ -317,7 +317,6 @@
             }
           },
           "required": [
-            "data_key",
             "timestamp_key"
           ],
           "additionalProperties": false

--- a/api-service/src/controllers/DatasetStatusTransition/ReadyToPublishSchema.json
+++ b/api-service/src/controllers/DatasetStatusTransition/ReadyToPublishSchema.json
@@ -337,7 +337,8 @@
           },
           "required": [
             "redis_db_host",
-            "redis_db_port"
+            "redis_db_port",
+            "redis_db"
           ],
           "additionalProperties": false
         }

--- a/api-service/src/services/DatasetService.ts
+++ b/api-service/src/services/DatasetService.ts
@@ -361,7 +361,7 @@ class DatasetService {
     private updateDruidDataSource = async (draftDataset: Record<string, any>, transaction: Transaction) => {
 
         const { created_by, updated_by } = draftDataset;
-        const existingDatasource = await Datasource.findAll({ where: { dataset_id: draftDataset.dataset_id }, attributes: ["dataset_id", "id", "metadata", "datasource"], raw: true }) as unknown as Record<string, any>
+        const existingDatasource = await Datasource.findAll({ where: { dataset_id: draftDataset.dataset_id }, raw: true }) as unknown as Record<string, any>
         const getDatasetDatasource = _.find(existingDatasource, datasource => !_.get(datasource, "metadata.aggregated") && _.get(datasource, "metadata.granularity") === "day")
         if (_.isEmpty(getDatasetDatasource)) {
             throw obsrvError("", "DATASOURCE_NOT_FOUND", `Datasource not found for dataset ${draftDataset.dataset_id}`, "BAD_REQUEST", 400)
@@ -372,6 +372,7 @@ class DatasetService {
         _.set(draftDatasource, "ingestion_spec", ingestionSpec)
         _.set(draftDatasource, "created_by", created_by);
         _.set(draftDatasource, "updated_by", updated_by);
+        _.set(draftDatasource, "type", "druid");
         await DatasourceDraft.upsert(draftDatasource, { transaction })
     }
 

--- a/api-service/src/services/DatasetService.ts
+++ b/api-service/src/services/DatasetService.ts
@@ -321,12 +321,16 @@ class DatasetService {
         const transaction = await sequelize.transaction()
         try {
             await DatasetDraft.update(draftDataset, { where: { id: draftDataset.id }, transaction })
+            const liveDataset = await this.getDataset(draftDataset.dataset_id, ["id", "api_version"], true);
             if (indexingConfig.olap_store_enabled) {
-                await this.createDruidDataSource(draftDataset, transaction);
+                if (liveDataset && liveDataset.api_version === "v1") {
+                    await this.updateDruidDataSource(draftDataset, transaction);
+                }
+                else {
+                    await this.createDruidDataSource(draftDataset, transaction);
+                }
             }
             if (indexingConfig.lakehouse_enabled) {
-                const liveDataset = await this.getDataset(draftDataset.dataset_id, ["id", "api_version"], true);
-
                 if (liveDataset && liveDataset.api_version === "v2") {
                     await this.updateHudiDataSource(draftDataset, transaction)
                 } else {
@@ -348,6 +352,23 @@ class DatasetService {
         const allFields = await tableGenerator.getAllFields(draftDataset, "druid");
         const draftDatasource = this.createDraftDatasource(draftDataset, "druid");
         const ingestionSpec = tableGenerator.getDruidIngestionSpec(draftDataset, allFields, draftDatasource.datasource_ref);
+        _.set(draftDatasource, "ingestion_spec", ingestionSpec)
+        _.set(draftDatasource, "created_by", created_by);
+        _.set(draftDatasource, "updated_by", updated_by);
+        await DatasourceDraft.upsert(draftDatasource, { transaction })
+    }
+
+    private updateDruidDataSource = async (draftDataset: Record<string, any>, transaction: Transaction) => {
+
+        const { created_by, updated_by } = draftDataset;
+        const existingDatasource = await Datasource.findAll({ where: { dataset_id: draftDataset.dataset_id }, attributes: ["dataset", "id", "metadata", "datasource"], raw: true }) as unknown as Record<string, any>
+        const getDatasetDatasource = _.find(existingDatasource, datasource => !_.get(datasource, "metadata.aggregated") && _.get(datasource, "metadata.granularity") === "day")
+        if (_.isEmpty(getDatasetDatasource)) {
+            throw obsrvError("", "DATASOURCE_NOT_FOUND", `Datasource not found for dataset ${draftDataset.dataset_id}`, "BAD_REQUEST", 400)
+        }
+        const allFields = await tableGenerator.getAllFields(draftDataset, "druid");
+        const ingestionSpec = tableGenerator.getDruidIngestionSpec(draftDataset, allFields, getDatasetDatasource.datasource_ref);
+        let draftDatasource = getDatasetDatasource
         _.set(draftDatasource, "ingestion_spec", ingestionSpec)
         _.set(draftDatasource, "created_by", created_by);
         _.set(draftDatasource, "updated_by", updated_by);

--- a/api-service/src/services/DatasetService.ts
+++ b/api-service/src/services/DatasetService.ts
@@ -361,7 +361,7 @@ class DatasetService {
     private updateDruidDataSource = async (draftDataset: Record<string, any>, transaction: Transaction) => {
 
         const { created_by, updated_by } = draftDataset;
-        const existingDatasource = await Datasource.findAll({ where: { dataset_id: draftDataset.dataset_id }, attributes: ["dataset", "id", "metadata", "datasource"], raw: true }) as unknown as Record<string, any>
+        const existingDatasource = await Datasource.findAll({ where: { dataset_id: draftDataset.dataset_id }, attributes: ["dataset_id", "id", "metadata", "datasource"], raw: true }) as unknown as Record<string, any>
         const getDatasetDatasource = _.find(existingDatasource, datasource => !_.get(datasource, "metadata.aggregated") && _.get(datasource, "metadata.granularity") === "day")
         if (_.isEmpty(getDatasetDatasource)) {
             throw obsrvError("", "DATASOURCE_NOT_FOUND", `Datasource not found for dataset ${draftDataset.dataset_id}`, "BAD_REQUEST", 400)

--- a/api-service/src/services/DatasetService.ts
+++ b/api-service/src/services/DatasetService.ts
@@ -151,16 +151,6 @@ class DatasetService {
                 mode: _.get(config, ["mode"])
             }
         })
-        const connectorsFields = ["id", "connector_type", "connector_config"]
-        const connectors = _.includes([DatasetStatus.Live], status) ? await this.getConnectorsV1(dataset_id, connectorsFields) : await this.getDraftConnectors(dataset_id, connectorsFields);
-        draftDataset["connectors_config"] = _.map(connectors, (config) => {
-            return {
-                id: _.get(config, ["id"]),
-                connector_id: _.get(config, ["connector_type"]),
-                connector_config: _.get(config, ["connector_config"]),
-                version: "v1"
-            }
-        })
         draftDataset["validation_config"] = _.omit(_.get(dataset, "validation_config"), ["validation_mode"])
         draftDataset["sample_data"] = dataset_config?.mergedEvent
         draftDataset["status"] = DatasetStatus.Draft
@@ -192,15 +182,6 @@ class DatasetService {
                 keys_config: { data_key: dataset_config.data_key, timestamp_key: dataset_config.timestamp_key },
                 cache_config: { redis_db_host: dataset_config.redis_db_host, redis_db_port: dataset_config.redis_db_port, redis_db: dataset_config.redis_db }
             }
-            const connectors = await this.getConnectorsV1(draftDataset.dataset_id, ["id", "connector_type", "connector_config"]);
-            draftDataset["connectors_config"] = _.map(connectors, (config) => {
-                return {
-                    id: _.get(config, "id"),
-                    connector_id: _.get(config, "connector_type"),
-                    connector_config: _.get(config, "connector_config"),
-                    version: "v1"
-                }
-            })
             const transformations = await this.getTransformations(draftDataset.dataset_id, ["field_key", "transformation_function", "mode", "metadata"]);
             draftDataset["transformations_config"] = _.map(transformations, (config) => {
                 const section: any = _.get(config, "metadata.section");
@@ -219,9 +200,8 @@ class DatasetService {
             draftDataset["sample_data"] = dataset_config?.mergedEvent
             draftDataset["validation_config"] = _.omit(_.get(dataset, "validation_config"), ["validation_mode"])
         } else {
-            const v1connectors = await getV1Connectors(draftDataset.dataset_id);
             const v2connectors = await this.getConnectors(draftDataset.dataset_id, ["id", "connector_id", "connector_config", "operations_config"]);
-            draftDataset["connectors_config"] = _.concat(v1connectors, v2connectors)
+            draftDataset["connectors_config"] = v2connectors;
             const transformations = await this.getTransformations(draftDataset.dataset_id, ["field_key", "transformation_function", "mode"]);
             draftDataset["transformations_config"] = transformations
         }
@@ -417,9 +397,7 @@ export const getLiveDatasetConfigs = async (dataset_id: string) => {
 
     const datasetRecord = await datasetService.getDataset(dataset_id, undefined, true)
     const transformations = await datasetService.getTransformations(dataset_id, ["field_key", "transformation_function", "mode"])
-    const connectorsV2 = await datasetService.getConnectors(dataset_id, ["id", "connector_id", "connector_config", "operations_config"])
-    const connectorsV1 = await getV1Connectors(dataset_id)
-    const connectors = _.concat(connectorsV1, connectorsV2)
+    const connectors = await datasetService.getConnectors(dataset_id, ["id", "connector_id", "connector_config", "operations_config"])
 
     if (!_.isEmpty(transformations)) {
         datasetRecord["transformations_config"] = transformations
@@ -430,18 +408,6 @@ export const getLiveDatasetConfigs = async (dataset_id: string) => {
     return datasetRecord;
 }
 
-export const getV1Connectors = async (datasetId: string) => {
-    const v1connectors = await datasetService.getConnectorsV1(datasetId, ["id", "connector_type", "connector_config"]);
-    const modifiedV1Connectors = _.map(v1connectors, (config) => {
-        return {
-            id: _.get(config, "id"),
-            connector_id: _.get(config, "connector_type"),
-            connector_config: _.get(config, "connector_config"),
-            version: "v1"
-        }
-    })
-    return modifiedV1Connectors;
-}
 
 const storageTypes = JSON.parse(config.storage_types)
 export const validateStorageSupport = (dataset: Record<string, any>) => {


### PR DESCRIPTION
**Description**

V1- V2 Migration Changes

- Updating only ingestion spec if the live druid datasource already exists 
- Expect data_key[primary_key] only if lakehouse or cache enabled is true
- ReadyToPublish schema update with redis_db as required field.
- V1 connectors must be ignored while v1 to v2 migration. 