### PR TITLE
feat #OBS-I649 : set channel as a reciever for a alert rule

### DIFF
--- a/api-service/src/controllers/DatasetRead/DatasetRead.ts
+++ b/api-service/src/controllers/DatasetRead/DatasetRead.ts
@@ -82,7 +82,7 @@ const readDataset = async (datasetId: string, attributes: string[]): Promise<any
     const api_version = _.get(dataset, "api_version")
     const datasetConfigs: any = {}
     const transformations_config = await datasetService.getTransformations(datasetId, ["field_key", "transformation_function", "mode", "metadata"])
-    const datasourceConfig = await Datasource.findOne({ where: { dataset_id: datasetId, is_primary: true }, attributes: ["datasource"], raw: true })
+    const datasourceConfig = await Datasource.findOne({ where: { dataset_id: datasetId, is_primary: true, type: "druid" }, attributes: ["datasource"], raw: true })
     datasetConfigs["alias"] = _.get(datasourceConfig, "datasource")
     if (api_version !== "v2") {
         datasetConfigs["transformations_config"] = _.map(transformations_config, (config) => {

--- a/api-service/src/services/DatasetService.ts
+++ b/api-service/src/services/DatasetService.ts
@@ -144,7 +144,7 @@ class DatasetService {
                 {
                     model: Datasource,
                     attributes: ['datasource'],
-                    where: { is_primary: true },
+                    where: { is_primary: true, type: "druid" },
                     required: false
                 },
             ], raw: true, where: filters, attributes, order: [["updated_date", "DESC"]]


### PR DESCRIPTION
https://sprints.zoho.in/workspace/sanketika#P2/itemdetails/I649/details
1. Return only the druid table details for dataset list and read
2. Set notification channel as contact point for alert rule instead of label matcher