### PR TITLE
feat #OBS-I649 : update id the hudi spec exists or else create

### DIFF
--- a/api-service/src/services/DatasetService.ts
+++ b/api-service/src/services/DatasetService.ts
@@ -458,7 +458,13 @@ class DatasetService {
         const draftDatasource = this.createDraftDatasource(draftDataset, "datalake");
         const dsId = _.join([draftDataset.dataset_id, "events", "datalake"], "_")
         const liveDatasource = await Datasource.findOne({ where: { id: dsId }, attributes: ["ingestion_spec"], raw: true }) as unknown as Record<string, any>
-        const ingestionSpec = tableGenerator.getHudiIngestionSpecForUpdate(draftDataset, liveDatasource?.ingestion_spec, allFields, draftDatasource?.datasource_ref);
+        let ingestionSpec = _.get(liveDatasource, "ingestion_spec");
+        if (_.isEmpty(ingestionSpec)) {
+            ingestionSpec = tableGenerator.getHudiIngestionSpecForCreate(draftDataset, allFields, draftDatasource.datasource_ref);
+        }
+        else {
+            ingestionSpec = tableGenerator.getHudiIngestionSpecForUpdate(draftDataset, liveDatasource?.ingestion_spec, allFields, draftDatasource?.datasource_ref);
+        }
         _.set(draftDatasource, "ingestion_spec", ingestionSpec)
         _.set(draftDatasource, "created_by", created_by);
         _.set(draftDatasource, "updated_by", updated_by);

--- a/api-service/src/services/TableGenerator.ts
+++ b/api-service/src/services/TableGenerator.ts
@@ -225,7 +225,7 @@ class TableGenerator extends BaseTableGenerator {
                 oldColumnSpec.push({
                     "type": col.type,
                     "name": col.name,
-                    "index": currIndex++
+                    "index": ++currIndex
                 })
             })
         }


### PR DESCRIPTION
1. Create a new hudi spec if ingestion spec doesnt exist or else update the existing table if exists
2. The current index has post increment which doesnt update and save the index, while hudi update.