### PR TITLE
feat: enable Dependabot and dependency submission for all services

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/api-service"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/command-service"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/system-rules-ingestor"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,83 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+
+  submit-api-service-deps:
+    name: Submit api-service (npm)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Generate package-lock.json
+        working-directory: api-service
+        run: npm install --package-lock-only
+
+      - name: Submit dependency snapshot
+        uses: advanced-security/component-detection-dependency-submission-action@v0.1.1
+        with:
+          filePath: api-service
+          detectorArgs: NpmLockfile3=EnableIfDefaultOff
+          correlator: api-service
+
+  submit-command-service-deps:
+    name: Submit command-service (pip)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Submit dependency snapshot
+        uses: advanced-security/component-detection-dependency-submission-action@v0.1.1
+        with:
+          filePath: command-service
+          detectorArgs: Pip=EnableIfDefaultOff,SimplePip=EnableIfDefaultOff
+          correlator: command-service
+
+  submit-system-rules-ingestor-deps:
+    name: Submit system-rules-ingestor (npm)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Generate package-lock.json
+        working-directory: system-rules-ingestor
+        run: npm install --package-lock-only
+
+      - name: Submit dependency snapshot
+        uses: advanced-security/component-detection-dependency-submission-action@v0.1.1
+        with:
+          filePath: system-rules-ingestor
+          detectorArgs: NpmLockfile3=EnableIfDefaultOff
+          correlator: system-rules-ingestor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+**obsrv-api-service** is a monorepo for the Obsrv data platform. The primary service is a Node.js/TypeScript REST API (`api-service/`) that manages datasets, data ingestion/egress, querying, and configuration. A Python microservice (`command-service/`) handles long-running cluster operations.
+
+## Commands
+
+All commands below should be run from the `api-service/` directory unless noted.
+
+```bash
+# Install dependencies
+npm install
+
+# Run tests (full suite with coverage)
+npm run test
+
+# Run a single test file
+npx mocha ./src/tests/DatasetManagement/DatasetRead/DatasetRead.spec.ts --exit
+
+# Lint
+npm run lint          # check
+npm run lint-fix      # auto-fix
+
+# Build TypeScript to dist/
+npm run build
+
+# Start development server (port 3000)
+npm run start
+```
+
+## Architecture
+
+### Monorepo Layout
+
+- `api-service/` — Main TypeScript/Express service (Node.js 24, port 3000)
+- `command-service/` — Python 3.12 microservice (Uvicorn, port 8000) for kubectl/Helm operations
+- `system-rules-ingestor/` — Node.js utility for ingesting system rules via HTTP
+
+### api-service Layers
+
+**Entry point:** `src/app.ts` → routes defined in `src/routes/Router.ts`
+
+All V2 API endpoints are prefixed with `/v2/`. Routes delegate to controllers.
+
+| Layer | Location | Role |
+|---|---|---|
+| Routes | `src/routes/` | Maps HTTP paths to controllers |
+| Controllers | `src/controllers/` | Request handling, input validation, response shaping |
+| Services | `src/services/` | Business logic, orchestration |
+| Models | `src/models/` | Sequelize ORM models (PostgreSQL) |
+| Middleware | `src/middlewares/` | RBAC, audit logging, error handling |
+| Config | `src/configs/Config.ts` | All environment-driven configuration |
+
+**Key controllers** are organized by domain: `Dataset*`, `DataIngestion`, `DataEgress`, `Connectors*`, `QueryTemplate*`, `Alerts*`, `SchemaGeneration`.
+
+**Key services:**
+- `DatasetService.ts` — Core dataset CRUD operations
+- `DatasetHealthService.ts` — Health monitoring
+- `DatasetMetricsService.ts` — Metrics aggregation
+- `WrapperService.ts` — Query wrapping (Druid/Trino)
+- `CloudServices/` — Multi-cloud abstraction (AWS S3, GCS, Azure Blob)
+- `telemetry.ts` — Audit event emission
+- `otel/` — OpenTelemetry integration
+
+### External Dependencies
+
+- **PostgreSQL** — Primary store (Sequelize ORM), default: `localhost:5432`, db `sb-obsrv`
+- **Redis** — Two instances: denorm cache and dedup (default: `localhost:6379`)
+- **Kafka** — Ingestion pipeline (default: `localhost:9092`)
+- **Druid** — Default query engine (`http://localhost:8888`)
+- **Trino** — Alternative query engine
+- **Prometheus** — Metrics (`http://localhost:9090`)
+
+### Testing Approach
+
+Tests live in `src/tests/` organized by feature domain. Tests use:
+- **Mocha** as the runner (`--exit` flag always required)
+- **Chai + Chai-HTTP** for HTTP assertions
+- **Chai-spies / Sinon** for stubbing Sequelize model methods (no real DB needed in unit tests)
+- **Nyc** for coverage (output to `coverage/`)
+
+Test environment is configured via `.env.test`.
+
+### TypeScript Configuration
+
+- Target: ES2016, Module: CommonJS
+- Source root: `src/`, output: `dist/`
+- Strict mode on; no implicit `any`
+- ESLint enforces double quotes
+
+### Query Limits (defaults from Config.ts)
+
+- `max_query_threshold` / `max_query_limit`: 5000 rows
+- `max_date_range`: 30 days
+- Excluded datasources (skip validation): `system-stats`, `failed-events-summary`, `masterdata-system-stats`, `system-events`


### PR DESCRIPTION
- Add .github/dependabot.yml for weekly version-update PRs covering api-service (npm), command-service (pip), system-rules-ingestor (npm), and GitHub Actions
- Add .github/workflows/dependency-submission.yml with three parallel jobs (api-service, command-service, system-rules-ingestor) that submit full dependency graphs (direct + transitive) to the GitHub Dependency Graph via the Dependency Submission API on push/PR to main and manual dispatch
- Add CLAUDE.md with codebase guidance for Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly dependency update checks for GitHub Actions, npm, and pip packages across services.
  * Added GitHub Actions workflow to automatically submit dependency snapshots for security monitoring.

* **Documentation**
  * Added developer documentation covering monorepo structure, architecture, and development setup guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->