### PR TITLE
Batching of metrics and health data in dataset list api

### DIFF
--- a/api-service/src/configs/Config.ts
+++ b/api-service/src/configs/Config.ts
@@ -29,6 +29,7 @@ export const config = {
       "sql_query_path": "/druid/v2/sql/",
       "native_query_path": "/druid/v2",
       "list_datasources_path": "/druid/v2/datasources",
+      "list_datasources_with_size_path": "/druid/coordinator/v1/datasources?simple",
       "submit_ingestion": "druid/indexer/v1/supervisor",
       "username": process.env.druid_username || "admin",
       "password": process.env.druid_password || "admin123"

--- a/api-service/src/connections/druidConnection.ts
+++ b/api-service/src/connections/druidConnection.ts
@@ -42,6 +42,15 @@ export const getDatasourceListFromDruid = async () => {
     return existingDatasources;
 }
 
+export const getDatasourceListWithSizeFromDruid = async () => {
+    return axios.get(`${druidHost}:${druidPort}${config.query_api.druid.list_datasources_with_size_path}`, {
+        auth: {
+            username: druidUsername,
+            password: druidPassword,
+        }
+    });
+}
+
 export const druidHttpService = axios.create({ 
     baseURL: `${config.query_api.druid.host}:${config.query_api.druid.port}`, 
     headers: { "Content-Type": "application/json" },

--- a/api-service/src/controllers/DatasetList/DatasetList.ts
+++ b/api-service/src/controllers/DatasetList/DatasetList.ts
@@ -49,8 +49,8 @@ const listDatasets = async (request: Record<string, any>): Promise<Record<string
         liveDatasetList = await attachLiveConnectors(liveDatasetList, connectorFilter);
         draftDatasetList = await attachDraftConnectors(draftDatasetList, connectorFilter);
     }
-    const combined = _.compact(_.concat(liveDatasetList, draftDatasetList));
-    return enrichDatasetsWithMetrics(combined);
+    const enrichedLive = await enrichDatasetsWithMetrics(liveDatasetList);
+    return _.compact(_.concat(enrichedLive, draftDatasetList));
 }
 
 export default datasetList;

--- a/api-service/src/controllers/DatasetList/DatasetList.ts
+++ b/api-service/src/controllers/DatasetList/DatasetList.ts
@@ -8,6 +8,7 @@ import { ResponseHandler } from "../../helpers/ResponseHandler";
 import { attachDraftConnectors, attachLiveConnectors, datasetService } from "../../services/DatasetService";
 import { obsrvError } from "../../types/ObsrvError";
 import { config } from "../../configs/Config";
+import { enrichDatasetsWithMetrics } from "./DatasetListMetrics";
 
 export const apiId = "api.datasets.list"
 export const errorCode = "DATASET_LIST_FAILURE"
@@ -48,7 +49,8 @@ const listDatasets = async (request: Record<string, any>): Promise<Record<string
         liveDatasetList = await attachLiveConnectors(liveDatasetList, connectorFilter);
         draftDatasetList = await attachDraftConnectors(draftDatasetList, connectorFilter);
     }
-    return _.compact(_.concat(liveDatasetList, draftDatasetList));
+    const combined = _.compact(_.concat(liveDatasetList, draftDatasetList));
+    return enrichDatasetsWithMetrics(combined);
 }
 
 export default datasetList;

--- a/api-service/src/controllers/DatasetList/DatasetListMetrics.ts
+++ b/api-service/src/controllers/DatasetList/DatasetListMetrics.ts
@@ -1,10 +1,12 @@
 import _ from "lodash";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import { executeNativeQuery, getDatasourceListWithSizeFromDruid } from "../../connections/druidConnection";
 import { getDatasetHealth } from "../../services/DatasetHealthService";
 import { HealthStatus } from "../../types/DatasetModels";
 import logger from "../../logger";
-const dateFormat = "YYYY-MM-DDT00:00:00+05:30";
+
+dayjs.extend(utc);
 
 /**
  * Build a batch timeseries query that counts events for ALL dataset IDs in one Druid round-trip.
@@ -133,11 +135,11 @@ export const enrichDatasetsWithMetrics = async (datasets: Record<string, any>[])
     if (datasets.length === 0) return [];
 
     const datasetIds = datasets.map((d) => d.dataset_id);
-    const now = dayjs();
-    const startOfToday = now.format(dateFormat);
-    const startOfYesterday = now.subtract(1, "day").format(dateFormat);
-    const endOfToday = now.add(1, "day").format(dateFormat);
-    const allTimeStart = "2000-01-01T00:00:00+05:30";
+    const now = dayjs.utc().startOf("day");
+    const startOfToday = now.toISOString();
+    const startOfYesterday = now.subtract(1, "day").toISOString();
+    const endOfToday = now.add(1, "day").toISOString();
+    const allTimeStart = "2000-01-01T00:00:00Z";
 
     const [
         totalEventsMap,

--- a/api-service/src/controllers/DatasetList/DatasetListMetrics.ts
+++ b/api-service/src/controllers/DatasetList/DatasetListMetrics.ts
@@ -130,20 +130,15 @@ const getDatasetHealthSummary = async (dataset: Record<string, any>): Promise<{ 
  * Non-Live datasets receive null metrics.
  */
 export const enrichDatasetsWithMetrics = async (datasets: Record<string, any>[]): Promise<Record<string, any>[]> => {
-    const liveDatasets = datasets.filter((d) => d.status === "Live");
+    if (datasets.length === 0) return [];
 
-    if (liveDatasets.length === 0) {
-        return datasets.map((d) => ({ ...d, health: null, unhealthy_components: [], metrics: null }));
-    }
-
-    const liveIds = liveDatasets.map((d) => d.dataset_id);
+    const datasetIds = datasets.map((d) => d.dataset_id);
     const now = dayjs();
     const startOfToday = now.format(dateFormat);
     const startOfYesterday = now.subtract(1, "day").format(dateFormat);
     const endOfToday = now.add(1, "day").format(dateFormat);
     const allTimeStart = "2000-01-01T00:00:00+05:30";
 
-    // All queries fire in parallel
     const [
         totalEventsMap,
         eventsTodayMap,
@@ -152,21 +147,17 @@ export const enrichDatasetsWithMetrics = async (datasets: Record<string, any>[])
         druidSizes,
         healthResults
     ] = await Promise.all([
-        executeBatchQuery(batchTotalEventsQuery(`${allTimeStart}/${endOfToday}`, liveIds), "total_events_count"),
-        executeBatchQuery(batchTotalEventsQuery(`${startOfToday}/${endOfToday}`, liveIds), "total_events_count"),
-        executeBatchQuery(batchTotalEventsQuery(`${startOfYesterday}/${startOfToday}`, liveIds), "total_events_count"),
-        executeBatchQuery(batchFailedEventsQuery(`${startOfToday}/${endOfToday}`, liveIds), "failed_events_count"),
+        executeBatchQuery(batchTotalEventsQuery(`${allTimeStart}/${endOfToday}`, datasetIds), "total_events_count"),
+        executeBatchQuery(batchTotalEventsQuery(`${startOfToday}/${endOfToday}`, datasetIds), "total_events_count"),
+        executeBatchQuery(batchTotalEventsQuery(`${startOfYesterday}/${startOfToday}`, datasetIds), "total_events_count"),
+        executeBatchQuery(batchFailedEventsQuery(`${startOfToday}/${endOfToday}`, datasetIds), "failed_events_count"),
         getDruidDatasourceSizes(),
-        Promise.all(liveDatasets.map((d) => getDatasetHealthSummary(d).then((h) => ({ dataset_id: d.dataset_id, ...h }))))
+        Promise.all(datasets.map((d) => getDatasetHealthSummary(d).then((h) => ({ dataset_id: d.dataset_id, ...h }))))
     ]);
 
     const healthMap = _.keyBy(healthResults, "dataset_id");
 
     return datasets.map((dataset) => {
-        if (dataset.status !== "Live") {
-            return { ...dataset, health: null, unhealthy_components: [], metrics: null };
-        }
-
         const id = dataset.dataset_id;
         const datasourceRef: string | undefined = dataset.datasource_ref;
         const healthInfo = healthMap[id] || { health: null, unhealthy_components: [] };

--- a/api-service/src/controllers/DatasetList/DatasetListMetrics.ts
+++ b/api-service/src/controllers/DatasetList/DatasetListMetrics.ts
@@ -1,0 +1,187 @@
+import _ from "lodash";
+import dayjs from "dayjs";
+import { executeNativeQuery, getDatasourceListWithSizeFromDruid } from "../../connections/druidConnection";
+import { getDatasetHealth } from "../../services/DatasetHealthService";
+import { HealthStatus } from "../../types/DatasetModels";
+import logger from "../../logger";
+const dateFormat = "YYYY-MM-DDT00:00:00+05:30";
+
+/**
+ * Build a batch timeseries query that counts events for ALL dataset IDs in one Druid round-trip.
+ * Returns rows grouped by ctx_dataset.
+ */
+const batchTotalEventsQuery = (intervals: string, datasetIds: string[]) => ({
+    queryType: "groupBy",
+    dataSource: { type: "table", name: "system-events" },
+    intervals: { type: "intervals", intervals: [intervals] },
+    granularity: { type: "all", timeZone: "UTC" },
+    filter: {
+        type: "in",
+        dimension: "ctx_dataset",
+        values: datasetIds
+    },
+    dimensions: [{ type: "default", dimension: "ctx_dataset", outputName: "ctx_dataset" }],
+    aggregations: [
+        { type: "longSum", name: "total_events_count", fieldName: "count" }
+    ]
+});
+
+/**
+ * Build a batch groupBy query for failed events (validator failed) for ALL datasets.
+ */
+const batchFailedEventsQuery = (intervals: string, datasetIds: string[]) => ({
+    queryType: "groupBy",
+    dataSource: { type: "table", name: "system-events" },
+    intervals: { type: "intervals", intervals: [intervals] },
+    granularity: { type: "all", timeZone: "UTC" },
+    filter: {
+        type: "and",
+        fields: [
+            {
+                type: "in",
+                dimension: "ctx_dataset",
+                values: datasetIds
+            },
+            {
+                type: "equals",
+                column: "ctx_pdata_pid",
+                matchValueType: "STRING",
+                matchValue: "validator"
+            },
+            {
+                type: "equals",
+                column: "error_pdata_status",
+                matchValueType: "STRING",
+                matchValue: "failed"
+            }
+        ]
+    },
+    dimensions: [{ type: "default", dimension: "ctx_dataset", outputName: "ctx_dataset" }],
+    aggregations: [
+        { type: "longSum", name: "failed_events_count", fieldName: "count" }
+    ]
+});
+
+/**
+ * Execute a batch Druid query and return a map of dataset_id -> count.
+ * Returns {} on failure so callers can gracefully fall back to 0.
+ */
+const executeBatchQuery = async (query: object, countField: string): Promise<Record<string, number>> => {
+    try {
+        const result = await executeNativeQuery(query);
+        const rows: any[] = _.get(result, "data", []);
+        return _.reduce(rows, (acc, row) => {
+            const datasetId: string = _.get(row, "event.ctx_dataset") || _.get(row, "ctx_dataset");
+            const count: number = _.get(row, `event.${countField}`) ?? _.get(row, countField) ?? 0;
+            if (datasetId) acc[datasetId] = count;
+            return acc;
+        }, {} as Record<string, number>);
+    } catch (err) {
+        logger.warn({ message: "Batch Druid query failed, metrics will be 0", err });
+        return {};
+    }
+};
+
+/**
+ * Fetch Druid datasource sizes keyed by datasource_ref (exact Druid name).
+ * Returns a map of datasource_ref -> size_in_bytes.
+ */
+const getDruidDatasourceSizes = async (): Promise<Record<string, number>> => {
+    try {
+        const result = await getDatasourceListWithSizeFromDruid();
+        const datasources: any[] = _.get(result, "data", []);
+        return _.reduce(datasources, (acc, ds: any) => {
+            if (ds && ds.name) {
+                const size = _.get(ds, "properties.segments.replicatedSize", 0);
+                acc[ds.name] = (acc[ds.name] || 0) + size;
+            }
+            return acc;
+        }, {} as Record<string, number>);
+    } catch (err) {
+        logger.warn({ message: "Failed to fetch Druid datasource sizes", err });
+        return {};
+    }
+};
+
+/**
+ * Run a health check for a single Live dataset, returning { status, unhealthy_components }.
+ * Never throws — returns UnHealthy on error.
+ */
+const getDatasetHealthSummary = async (dataset: Record<string, any>): Promise<{ health: string; unhealthy_components: string[] }> => {
+    try {
+        const result = await getDatasetHealth(["infra", "processing"], dataset);
+        const unhealthy = _.compact(
+            _.flatMap(_.get(result, "details", []), (detail: any) =>
+                _.map(
+                    _.filter(detail.components, (c: any) => c.status === HealthStatus.UnHealthy),
+                    (c: any) => c.type
+                )
+            )
+        );
+        return { health: result.status, unhealthy_components: unhealthy };
+    } catch (err) {
+        logger.warn({ message: `Health check failed for dataset ${dataset.dataset_id}`, err });
+        return { health: HealthStatus.UnHealthy, unhealthy_components: [] };
+    }
+};
+
+/**
+ * Enrich a list of Live datasets with parallel health + batch Druid metrics.
+ * Non-Live datasets receive null metrics.
+ */
+export const enrichDatasetsWithMetrics = async (datasets: Record<string, any>[]): Promise<Record<string, any>[]> => {
+    const liveDatasets = datasets.filter((d) => d.status === "Live");
+
+    if (liveDatasets.length === 0) {
+        return datasets.map((d) => ({ ...d, health: null, unhealthy_components: [], metrics: null }));
+    }
+
+    const liveIds = liveDatasets.map((d) => d.dataset_id);
+    const now = dayjs();
+    const startOfToday = now.format(dateFormat);
+    const startOfYesterday = now.subtract(1, "day").format(dateFormat);
+    const endOfToday = now.add(1, "day").format(dateFormat);
+    const allTimeStart = "2000-01-01T00:00:00+05:30";
+
+    // All queries fire in parallel
+    const [
+        totalEventsMap,
+        eventsTodayMap,
+        eventsYesterdayMap,
+        failedTodayMap,
+        druidSizes,
+        healthResults
+    ] = await Promise.all([
+        executeBatchQuery(batchTotalEventsQuery(`${allTimeStart}/${endOfToday}`, liveIds), "total_events_count"),
+        executeBatchQuery(batchTotalEventsQuery(`${startOfToday}/${endOfToday}`, liveIds), "total_events_count"),
+        executeBatchQuery(batchTotalEventsQuery(`${startOfYesterday}/${startOfToday}`, liveIds), "total_events_count"),
+        executeBatchQuery(batchFailedEventsQuery(`${startOfToday}/${endOfToday}`, liveIds), "failed_events_count"),
+        getDruidDatasourceSizes(),
+        Promise.all(liveDatasets.map((d) => getDatasetHealthSummary(d).then((h) => ({ dataset_id: d.dataset_id, ...h }))))
+    ]);
+
+    const healthMap = _.keyBy(healthResults, "dataset_id");
+
+    return datasets.map((dataset) => {
+        if (dataset.status !== "Live") {
+            return { ...dataset, health: null, unhealthy_components: [], metrics: null };
+        }
+
+        const id = dataset.dataset_id;
+        const datasourceRef: string | undefined = dataset.datasource_ref;
+        const healthInfo = healthMap[id] || { health: null, unhealthy_components: [] };
+
+        return {
+            ...dataset,
+            health: healthInfo.health,
+            unhealthy_components: healthInfo.unhealthy_components,
+            metrics: {
+                total_events: totalEventsMap[id] ?? 0,
+                events_today: eventsTodayMap[id] ?? 0,
+                events_yesterday: eventsYesterdayMap[id] ?? 0,
+                failed_today: failedTodayMap[id] ?? 0,
+                storage_size_bytes: datasourceRef ? (druidSizes[datasourceRef] ?? 0) : 0
+            }
+        };
+    });
+};

--- a/api-service/src/controllers/DatasetStatusTransition/DatasetStatusTransition.ts
+++ b/api-service/src/controllers/DatasetStatusTransition/DatasetStatusTransition.ts
@@ -93,6 +93,7 @@ const readyForPublish = async (dataset: Record<string, any>, updated_by: any) =>
     let defaultConfigs: any = _.cloneDeep(defaultDatasetConfig)
     defaultConfigs = _.omit(defaultConfigs, ["router_config"])
     defaultConfigs = _.omit(defaultConfigs, "dedup_config.dedup_key");
+    defaultConfigs = _.omit(defaultConfigs, ["validation_config"]);
     if (_.get(draftDataset, "dataset_config.keys_config")) {
         defaultConfigs = _.omit(defaultConfigs, "dataset_config.keys_config");
     }

--- a/api-service/src/controllers/DatasetUpdate/DatasetUpdate.ts
+++ b/api-service/src/controllers/DatasetUpdate/DatasetUpdate.ts
@@ -143,8 +143,8 @@ const getMissingFieldsInNewSchema = (newSchema: any, oldSchema: any) => {
 
 
     const getRemovedPropertiesFields = (oldSchema: any, newSchema: any): string[] => {
-        const oldProperties = oldSchema.properties || {};
-        const newProperties = newSchema.properties || {};
+        const oldProperties = oldSchema?.properties || {};
+        const newProperties = newSchema?.properties || {};
         return getRemovedPropertiesFieldsNested(oldProperties, newProperties);
     }
 

--- a/api-service/src/services/AlertManagerService.ts
+++ b/api-service/src/services/AlertManagerService.ts
@@ -115,13 +115,14 @@ class AlertManagerService {
                 const { id } = alert;
                 const ruleModel: Record<string, any> | null = await getAlertRule(id);
                 if (!ruleModel) {
-                    throw obsrvError(id, 'ALERT_RULE_NOT_FOUND', `Alert rule with id ${id} not found`, 'NOT_FOUND', 404);
+                    console.log(`Alert rule not found for id ${id} for dataset ${dataset_id}`);
+                    continue;
                 }
                 const rulePayload = ruleModel.toJSON();
                 await publishAlert(rulePayload);
             }
         } catch (error) {
-            console.log("Failed to Publish Alert Rules", error)
+            console.log(`Failed to Publish Alert Rules for dataset ${dataset_id}`, error)
         }
     }
 
@@ -134,8 +135,8 @@ class AlertManagerService {
     }
 
     public createDatasetAlertsDraft = async (dataset: Record<string, any>, transaction: Transaction, datasource_ref: string): Promise<void> => {
-        const existingAlerts = await Alert.findAll({ where: { "metadata.queryBuilderContext.subComponent": dataset.dataset_id }, transaction });
-        if (existingAlerts.length > 0) {
+        const existingDatasetAlerts = await Alert.findAll({ where: { "metadata.queryBuilderContext.subComponent": dataset.dataset_id }, transaction });
+        if (existingDatasetAlerts.length > 0) {
             console.log(`Alerts already exists for dataset ${dataset.dataset_id}`);
             return;
         }

--- a/api-service/src/services/AlertManagerService.ts
+++ b/api-service/src/services/AlertManagerService.ts
@@ -35,7 +35,7 @@ class AlertManagerService {
             metricData.metric = metricData.metric.replaceAll('dataset_id', modifiedSubstring);
         }
         else if (service === 'druid') {
-            metricData.metric = metricData.metric.replaceAll('dataset_id', 
+            metricData.metric = metricData.metric.replaceAll('dataset_id',
                 metricData.flattened ? (datasource_ref || '').replace(/-/g, '_') : datasource_ref
             );
         }
@@ -109,15 +109,19 @@ class AlertManagerService {
     }
 
     public publishAlertRule = async (dataset_id: string): Promise<void> => {
-        const datasetAlerts: any[] = await getAlertByDataset(dataset_id)
-        for (const alert of datasetAlerts) {
-            const { id } = alert;
-            const ruleModel: Record<string, any> | null = await getAlertRule(id);
-            if (!ruleModel) {
-                throw obsrvError(id, 'ALERT_RULE_NOT_FOUND', `Alert rule with id ${id} not found`, 'NOT_FOUND', 404);
+        try {
+            const datasetAlerts: any[] = await getAlertByDataset(dataset_id)
+            for (const alert of datasetAlerts) {
+                const { id } = alert;
+                const ruleModel: Record<string, any> | null = await getAlertRule(id);
+                if (!ruleModel) {
+                    throw obsrvError(id, 'ALERT_RULE_NOT_FOUND', `Alert rule with id ${id} not found`, 'NOT_FOUND', 404);
+                }
+                const rulePayload = ruleModel.toJSON();
+                await publishAlert(rulePayload);
             }
-            const rulePayload = ruleModel.toJSON();
-            await publishAlert(rulePayload);
+        } catch (error) {
+            console.log("Failed to Publish Alert Rules", error)
         }
     }
 
@@ -130,6 +134,11 @@ class AlertManagerService {
     }
 
     public createDatasetAlertsDraft = async (dataset: Record<string, any>, transaction: Transaction, datasource_ref: string): Promise<void> => {
+        const existingAlerts = await Alert.findAll({ where: { "metadata.queryBuilderContext.subComponent": dataset.dataset_id }, transaction });
+        if (existingAlerts.length > 0) {
+            console.log(`Alerts already exists for dataset ${dataset.dataset_id}`);
+            return;
+        }
         const allMetrics = [
             ...this.config.dataset_metrics_flink.map((metric: MetricConfig) => ({ service: 'flink', metric })),
             ...this.config.dataset_metrics_druid.map((metric: MetricConfig) => ({ service: 'druid', metric })),

--- a/api-service/src/services/DatasetService.ts
+++ b/api-service/src/services/DatasetService.ts
@@ -144,13 +144,13 @@ class DatasetService {
             include: [
                 {
                     model: Datasource,
-                    attributes: ['datasource'],
+                    attributes: ["datasource", "datasource_ref"],
                     where: { is_primary: true, type: "druid" },
                     required: false
                 },
             ], raw: true, where: filters, attributes, order: [["updated_date", "DESC"]]
         });
-        const updatedDatasets = _.map(datasets, (dataset) => ({ ...dataset, alias: _.get(dataset, "datasources.datasource") }))
+        const updatedDatasets = _.map(datasets, (dataset) => ({ ...dataset, alias: _.get(dataset, "datasources.datasource"), datasource_ref: _.get(dataset, "datasources.datasource_ref") }))
         return updatedDatasets;
     }
 

--- a/api-service/src/services/DatasetService.ts
+++ b/api-service/src/services/DatasetService.ts
@@ -138,7 +138,7 @@ class DatasetService {
         return DatasetTransformations.findAll({ where: { dataset_id }, attributes, raw: true });
     }
 
-    getLiveDatasets = async (filters: Record<string, any>, attributes?: string[]): Promise<Record<string, any>> => {
+    getLiveDatasets = async (filters: Record<string, any>, attributes?: string[]): Promise<Record<string, any>[]> => {
         Dataset.hasMany(Datasource, { foreignKey: 'dataset_id' });
         const datasets = await Dataset.findAll({
             include: [


### PR DESCRIPTION
Summary:
1. Batching of metrics and health data in dataset list api
2. Check for draft dataset alerts if already created for dataset and skip creation if already created, so that it must not block dataset publish scenario.
3. Skip patching dataset with hardcoded default validation config, so it must not cause bugs with default values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dataset listings now display enriched metrics including total events, daily event counts, failed events, storage size, and health status.

* **Bug Fixes**
  * Improved error handling for alert rule publishing with enhanced logging.
  * Prevented duplicate draft alert creation for existing alerts.
  * Enhanced schema validation to handle missing properties gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->