### PR TITLE
#fix: Data out api support for join queries.

### DIFF
--- a/api-service/src/controllers/DataOut/DataOutController.ts
+++ b/api-service/src/controllers/DataOut/DataOutController.ts
@@ -3,7 +3,7 @@ import logger from "../../logger";
 import { ResponseHandler } from "../../helpers/ResponseHandler";
 import { schemaValidation } from "../../services/ValidationService";
 import validationSchema from "./DataOutValidationSchema.json";
-import { validateQuery, setQueryLimits, checkSupervisorAvailability, buildSqlQuery } from "./QueryValidator";
+import { validateQuery, setQueryLimits, buildSqlQuery } from "./QueryValidator";
 import * as _ from "lodash";
 import { executeNativeQuery, executeSqlQuery } from "../../connections/druidConnection";
 import { datasetService } from "../../services/DatasetService";

--- a/api-service/src/controllers/DataOut/DataOutController.ts
+++ b/api-service/src/controllers/DataOut/DataOutController.ts
@@ -3,59 +3,121 @@ import logger from "../../logger";
 import { ResponseHandler } from "../../helpers/ResponseHandler";
 import { schemaValidation } from "../../services/ValidationService";
 import validationSchema from "./DataOutValidationSchema.json";
-import { validateQuery } from "./QueryValidator";
+import { validateQuery, setQueryLimits, checkSupervisorAvailability } from "./QueryValidator";
 import * as _ from "lodash";
-import { executeNativeQuery, executeSqlQuery } from "../../connections/druidConnection";
+import { executeNativeQuery, executeSqlQuery, getDatasourceListFromDruid, druidHttpService } from "../../connections/druidConnection";
 import { datasetService } from "../../services/DatasetService";
 import { obsrvError } from "../../types/ObsrvError";
+import { Parser } from "node-sql-parser";
 
 export const apiId = "api.data.out";
-export const query_data = {"data": {}};
+export const query_data = { "data": {} };
 
-const requestValidation = async (req: Request) => {
-    const datasourceKey = req.params?.dataset_id;
-    const isValidSchema = schemaValidation(req.body, validationSchema);
-    if (!isValidSchema?.isValid) {
-        throw obsrvError(datasourceKey, "DATA_OUT_INVALID_INPUT", isValidSchema?.message, "BAD_REQUEST", 400)
+const parser = new Parser();
+
+const buildSqlQuery = async (req: Request, query: string) => {
+    const ast: any = parser.astify(query, { database: "postgresql" });
+    const fromList = _.castArray(_.get(ast, "from", [])).filter(Boolean);
+    const tableParams = _.get(req, "query", {}) as Record<string, any>;
+
+    const missingParams: string[] = [];
+    const tableToRef: Record<string, string> = {};
+    _.forEach(fromList, (entry: any) => {
+        const table = _.get(entry, "table");
+        const ref = tableParams[table];
+        if (!_.isString(ref) || _.isEmpty(ref)) {
+            missingParams.push(table);
+        } else {
+            tableToRef[table] = ref;
+        }
+    });
+    if (!_.isEmpty(missingParams)) {
+        const logMsg = `Missing query param(s) for table(s): ${_.uniq(missingParams).join(", ")}`;
+        const errorMsg = "Invalid request: table mapping parameter is missing.";
+        logger.error({ apiId, message: logMsg });
+        throw obsrvError("", "DATA_OUT_MISSING_TABLE_PARAM", errorMsg, "BAD_REQUEST", 400);
     }
-    const datasource = await datasetService.getDatasourceWithKey(datasourceKey, ["datasource_ref", "dataset_id"], true)
+
+    // Verify each mapped datasource_ref exists in postgres.
+    const datasourceRefs = _.uniq(_.values(tableToRef));
+    const existing = await datasetService.getExistingDatasourceRefs(datasourceRefs);
+    const notFound = _.difference(datasourceRefs, _.map(existing, "datasource_ref"));
+    if (!_.isEmpty(notFound)) {
+        throw obsrvError("", "DATASOURCE_NOT_FOUND", `Datasource(s) not found: ${notFound.join(", ")}`, "NOT_FOUND", 404);
+    }
+
+    // Verify each mapped datasource_ref load status in Druid.
+    const msgid = _.get(req, "body.params.msgid");
+    for (const ref of datasourceRefs) {
+        await checkSupervisorAvailability(ref, req.body, msgid);
+    }
+
+    // Verify each mapped datasource_ref exists in Druid.
+    const druidDatasources = await getDatasourceListFromDruid();
+    const notInDruid = _.difference(datasourceRefs, druidDatasources.data);
+    if (!_.isEmpty(notInDruid)) {
+        throw obsrvError("", "DATASOURCE_NOT_FOUND", `Datasource(s) not available for querying: ${notInDruid.join(", ")}`, "NOT_FOUND", 404);
+    }
+
+    // Replace table names with the param values and emit SQL.
+    _.forEach(fromList, (entry: any) => { entry.table = tableToRef[entry.table]; });
+    const rewrittenQuery = parser.sqlify(ast, { database: "postgresql" }).replace(/`/g, "\"");
+    _.set(req, "body.query", rewrittenQuery);
+    return rewrittenQuery;
+};
+
+const dataOutSql = async (req: Request, res: Response, msgid: string, requestBody: any) => {
+    await buildSqlQuery(req, _.get(req, "body.query"));
+    setQueryLimits(req.body);
+    const cappedQuery = _.get(req, "body.query");
+    const result = await executeSqlQuery({ query: cappedQuery });
+    _.set(query_data, "data", result.data);
+    logger.info({ apiId, msgid, requestBody, message: "SQL query executed successfully" });
+    return ResponseHandler.successResponse(req, res, { status: 200, data: result?.data });
+};
+
+
+const nativeRequestValidation = async (req: Request) => {
+    const datasourceKey = req.params?.dataset_id;
+    const datasource = await datasetService.getDatasourceWithKey(datasourceKey, ["datasource_ref", "dataset_id"], true);
     if (_.isEmpty(datasource)) {
-        throw obsrvError(datasourceKey, "DATASET_NOT_FOUND", `Dataset with id/alias name '${datasourceKey}' not found`, "NOT_FOUND", 404)
+        throw obsrvError(datasourceKey, "DATASET_NOT_FOUND", `Dataset with id/alias name '${datasourceKey}' not found`, "NOT_FOUND", 404);
     }
     _.set(req, "body.request.dataset_id", datasource.dataset_id);
-    return datasource
-}
+    return datasource;
+};
 
-const dataOut = async (req: Request, res: Response) => {
-    const requestBody = req.body;
-    const msgid = _.get(req, "body.params.msgid");
-    const dataset = await requestValidation(req)
-    const { dataset_id: datasetId, datasource_ref } = dataset
+const dataOutNative = async (req: Request, res: Response, msgid: string, requestBody: any) => {
+    const dataset = await nativeRequestValidation(req);
+    const { dataset_id: datasetId, datasource_ref } = dataset;
     const isValidQuery: any = await validateQuery(req.body, datasetId, datasource_ref);
-    const query = _.get(req, "body.query", "")
+    const query = _.get(req, "body.query", "");
 
     if (isValidQuery === true && _.isObject(query)) {
         const result = await executeNativeQuery(query);
         _.set(query_data, "data", result.data);
-        logger.info({ apiId, msgid, requestBody, datasetId, message: "Native query executed successfully" })
-        return ResponseHandler.successResponse(req, res, {
-            status: 200, data: result?.data
-        });
+        logger.info({ apiId, msgid, requestBody, datasetId, message: "Native query executed successfully" });
+        return ResponseHandler.successResponse(req, res, { status: 200, data: result?.data });
     }
 
-    if (isValidQuery === true && _.isString(query)) {
-        const result = await executeSqlQuery({ query })
-        _.set(query_data, "data", result.data);
-        logger.info({ apiId, msgid, requestBody, datasetId, message: "SQL query executed successfully" })
-        return ResponseHandler.successResponse(req, res, {
-            status: 200, data: result?.data
-        });
+    logger.error({ apiId, msgid, requestBody, datasetId, message: isValidQuery?.message, code: isValidQuery?.code });
+    return ResponseHandler.errorResponse({ message: isValidQuery?.message, statusCode: isValidQuery?.statusCode, errCode: isValidQuery?.errCode, code: isValidQuery?.code }, req, res);
+};
+
+const dataOut = async (req: Request, res: Response) => {
+    const requestBody = req.body;
+    const msgid = _.get(req, "body.params.msgid");
+
+    const isValidSchema = schemaValidation(req.body, validationSchema);
+    if (!isValidSchema?.isValid) {
+        throw obsrvError(req.params?.dataset_id, "DATA_OUT_INVALID_INPUT", isValidSchema?.message, "BAD_REQUEST", 400);
     }
 
-    else {
-        logger.error({ apiId, msgid, requestBody, datasetId, message: isValidQuery?.message, code: isValidQuery?.code })
-        return ResponseHandler.errorResponse({ message: isValidQuery?.message, statusCode: isValidQuery?.statusCode, errCode: isValidQuery?.errCode, code: isValidQuery?.code }, req, res);
+    const query = _.get(req, "body.query");
+    if (_.isString(query)) {
+        return dataOutSql(req, res, msgid, requestBody);
     }
-}
+    return dataOutNative(req, res, msgid, requestBody);
+};
 
 export default dataOut;

--- a/api-service/src/controllers/DataOut/DataOutController.ts
+++ b/api-service/src/controllers/DataOut/DataOutController.ts
@@ -18,7 +18,7 @@ const dataOutSql = async (req: Request, res: Response, msgid: string, requestBod
     const cappedQuery = _.get(req, "body.query");
     const result = await executeSqlQuery({ query: cappedQuery });
     _.set(query_data, "data", result.data);
-    logger.info({ apiId, msgid, requestBody, message: "SQL query executed successfully" });
+    logger.info({ apiId, msgid, message: "SQL query executed successfully" });
     return ResponseHandler.successResponse(req, res, { status: 200, data: result?.data });
 };
 

--- a/api-service/src/controllers/DataOut/DataOutController.ts
+++ b/api-service/src/controllers/DataOut/DataOutController.ts
@@ -3,68 +3,14 @@ import logger from "../../logger";
 import { ResponseHandler } from "../../helpers/ResponseHandler";
 import { schemaValidation } from "../../services/ValidationService";
 import validationSchema from "./DataOutValidationSchema.json";
-import { validateQuery, setQueryLimits, checkSupervisorAvailability } from "./QueryValidator";
+import { validateQuery, setQueryLimits, checkSupervisorAvailability, buildSqlQuery } from "./QueryValidator";
 import * as _ from "lodash";
-import { executeNativeQuery, executeSqlQuery, getDatasourceListFromDruid, druidHttpService } from "../../connections/druidConnection";
+import { executeNativeQuery, executeSqlQuery } from "../../connections/druidConnection";
 import { datasetService } from "../../services/DatasetService";
 import { obsrvError } from "../../types/ObsrvError";
-import { Parser } from "node-sql-parser";
 
 export const apiId = "api.data.out";
 export const query_data = { "data": {} };
-
-const parser = new Parser();
-
-const buildSqlQuery = async (req: Request, query: string) => {
-    const ast: any = parser.astify(query, { database: "postgresql" });
-    const fromList = _.castArray(_.get(ast, "from", [])).filter(Boolean);
-    const tableParams = _.get(req, "query", {}) as Record<string, any>;
-
-    const missingParams: string[] = [];
-    const tableToRef: Record<string, string> = {};
-    _.forEach(fromList, (entry: any) => {
-        const table = _.get(entry, "table");
-        const ref = tableParams[table];
-        if (!_.isString(ref) || _.isEmpty(ref)) {
-            missingParams.push(table);
-        } else {
-            tableToRef[table] = ref;
-        }
-    });
-    if (!_.isEmpty(missingParams)) {
-        const logMsg = `Missing query param(s) for table(s): ${_.uniq(missingParams).join(", ")}`;
-        const errorMsg = "Invalid request: table mapping parameter is missing.";
-        logger.error({ apiId, message: logMsg });
-        throw obsrvError("", "DATA_OUT_MISSING_TABLE_PARAM", errorMsg, "BAD_REQUEST", 400);
-    }
-
-    // Verify each mapped datasource_ref exists in postgres.
-    const datasourceRefs = _.uniq(_.values(tableToRef));
-    const existing = await datasetService.getExistingDatasourceRefs(datasourceRefs);
-    const notFound = _.difference(datasourceRefs, _.map(existing, "datasource_ref"));
-    if (!_.isEmpty(notFound)) {
-        throw obsrvError("", "DATASOURCE_NOT_FOUND", `Datasource(s) not found: ${notFound.join(", ")}`, "NOT_FOUND", 404);
-    }
-
-    // Verify each mapped datasource_ref load status in Druid.
-    const msgid = _.get(req, "body.params.msgid");
-    for (const ref of datasourceRefs) {
-        await checkSupervisorAvailability(ref, req.body, msgid);
-    }
-
-    // Verify each mapped datasource_ref exists in Druid.
-    const druidDatasources = await getDatasourceListFromDruid();
-    const notInDruid = _.difference(datasourceRefs, druidDatasources.data);
-    if (!_.isEmpty(notInDruid)) {
-        throw obsrvError("", "DATASOURCE_NOT_FOUND", `Datasource(s) not available for querying: ${notInDruid.join(", ")}`, "NOT_FOUND", 404);
-    }
-
-    // Replace table names with the param values and emit SQL.
-    _.forEach(fromList, (entry: any) => { entry.table = tableToRef[entry.table]; });
-    const rewrittenQuery = parser.sqlify(ast, { database: "postgresql" }).replace(/`/g, "\"");
-    _.set(req, "body.query", rewrittenQuery);
-    return rewrittenQuery;
-};
 
 const dataOutSql = async (req: Request, res: Response, msgid: string, requestBody: any) => {
     await buildSqlQuery(req, _.get(req, "body.query"));

--- a/api-service/src/controllers/DataOut/QueryValidator.ts
+++ b/api-service/src/controllers/DataOut/QueryValidator.ts
@@ -223,7 +223,7 @@ export const checkSupervisorAvailability = async (datasourceRef: string, request
     }
     if (datasourceAvailability !== 100) {
         const logMsg = `Segments not fully published to the metadata store yet, current load: ${datasourceAvailability}%`;
-        const errorMsg = "Data is still loading. Please try again in a few minutes.";
+        const errorMsg = "Data is still loading. Please try after some time.";
         logger.error({ apiId, requestBody: reqBody, msgid: msgId, dataset_id: dId, message: logMsg, code: errCode.notFound })
         throw obsrvError("", "DATASOURCE_NOT_FULLY_AVAILABLE", errorMsg, "RANGE_NOT_SATISFIABLE", 416)
     }

--- a/api-service/src/controllers/DataOut/QueryValidator.ts
+++ b/api-service/src/controllers/DataOut/QueryValidator.ts
@@ -60,7 +60,7 @@ const getLimit = (queryLimit: number, maxRowLimit: number) => {
 
 const parseSqlQuery = (queryPayload: any) => {
     try {
-        const vocabulary: any = parser.astify(queryPayload?.query);
+        const vocabulary: any = parser.astify(queryPayload?.query, { database: "postgresql" });
         const isLimitIncludes = JSON.stringify(vocabulary);
         if (_.includes(isLimitIncludes, "{{LIMIT}}")) {
             return queryPayload?.query
@@ -69,9 +69,18 @@ const parseSqlQuery = (queryPayload: any) => {
         if (limit === null) {
             _.set(vocabulary, "limit.value[0].value", queryRules.common.maxResultRowLimit)
             _.set(vocabulary, "limit.value[0].type", "number")
-            let convertToSQL = parser.sqlify(vocabulary);
+            let convertToSQL = parser.sqlify(vocabulary, { database: "postgresql" });
             convertToSQL = convertToSQL.replace(/`/g, "\"");
             queryPayload.query = convertToSQL
+        } else if (Array.isArray(limit.value) && limit.value.length > 0) {
+            const limitIndex = limit.seperator === "," && limit.value.length > 1 ? 1 : 0;
+            const userLimit = limit.value[limitIndex].value;
+            if (typeof userLimit === "number" && userLimit > queryRules.common.maxResultRowLimit) {
+                limit.value[limitIndex].value = queryRules.common.maxResultRowLimit;
+                let convertToSQL = parser.sqlify(vocabulary, { database: "postgresql" });
+                convertToSQL = convertToSQL.replace(/`/g, "\"");
+                queryPayload.query = convertToSQL;
+            }
         }
         return true
     } catch (error) {
@@ -79,7 +88,7 @@ const parseSqlQuery = (queryPayload: any) => {
         return false
     }
 }
-const setQueryLimits = (queryPayload: any) => {
+export const setQueryLimits = (queryPayload: any) => {
     if (_.isObject(queryPayload?.query)) {
         const threshold = _.get(queryPayload, "query.threshold")
         if (threshold) {
@@ -196,16 +205,25 @@ const getDataSourceRef = async (datasetId: string, requestGranularity?: string) 
     return _.get(record, ["dataValues", "datasource_ref"])
 }
 
-const checkSupervisorAvailability = async (datasourceRef: string) => {
+export const checkSupervisorAvailability = async (datasourceRef: string, requestPayload?: any, messageId?: string, datasetId?: string) => {
     const { data } = await druidHttpService.get("/druid/coordinator/v1/loadstatus");
     const datasourceAvailability = _.get(data, datasourceRef)
+
+    const reqBody = requestPayload || requestBody;
+    const msgId = messageId || msgid;
+    const dId = datasetId || dataset_id;
+
     if (_.isUndefined(datasourceAvailability)) {
-        logger.error({ apiId, requestBody, msgid, dataset_id, message: `Segments not published to the metadata store yet, please check the coordinator load status`, code: errCode.notFound })
-        throw obsrvError("", "DATASOURCE_NOT_AVAILABLE", "Datasource not available for querying", "NOT_FOUND", 404)
+        const logMsg = "Segments not published to the metadata store yet, please check the coordinator load status";
+        const errorMsg = "Datasource not available for querying";
+        logger.error({ apiId, requestBody: reqBody, msgid: msgId, dataset_id: dId, message: logMsg, code: errCode.notFound })
+        throw obsrvError("", "DATASOURCE_NOT_AVAILABLE", errorMsg, "NOT_FOUND", 404)
     }
     if (datasourceAvailability !== 100) {
-        logger.error({ apiId, requestBody, msgid, dataset_id, message: `Segments not fully published to the metadata store yet, please check the coordinator load status`, code: errCode.notFound })
-        throw obsrvError("", "DATASOURCE_NOT_FULLY_AVAILABLE", "Datasource not fully available for querying", "RANGE_NOT_SATISFIABLE", 416)
+        const logMsg = `Segments not fully published to the metadata store yet, current load: ${datasourceAvailability}%`;
+        const errorMsg = "Data is still loading. Please try again in a few minutes.";
+        logger.error({ apiId, requestBody: reqBody, msgid: msgId, dataset_id: dId, message: logMsg, code: errCode.notFound })
+        throw obsrvError("", "DATASOURCE_NOT_FULLY_AVAILABLE", errorMsg, "RANGE_NOT_SATISFIABLE", 416)
     }
 }
 

--- a/api-service/src/controllers/DataOut/QueryValidator.ts
+++ b/api-service/src/controllers/DataOut/QueryValidator.ts
@@ -297,7 +297,13 @@ export const buildSqlQuery = async (req: Request, query: string) => {
     }
 
     // Replace table names with the param values and emit SQL.
-    _.forEach(fromList, (entry: any) => { entry.table = tableToRef[entry.table]; });
+    _.forEach(fromList, (entry: any) => {
+        const originalTable = entry.table;
+        entry.table = tableToRef[originalTable];
+        if (!entry.as || _.isEmpty(entry.as)) {
+            entry.as = originalTable;
+        }
+    });
     const rewrittenQuery = parser.sqlify(ast, { database: "postgresql" }).replace(/`/g, "\"");
     _.set(req, "body.query", rewrittenQuery);
     return rewrittenQuery;

--- a/api-service/src/controllers/DataOut/QueryValidator.ts
+++ b/api-service/src/controllers/DataOut/QueryValidator.ts
@@ -255,17 +255,15 @@ const setDatasourceRef = async (datasetId: string, payload: any): Promise<any> =
 export const buildSqlQuery = async (req: Request, query: string) => {
     const ast: any = parser.astify(query, { database: "postgresql" });
     const fromList = _.castArray(_.get(ast, "from", [])).filter(Boolean);
-    const tableParams = _.get(req, "query", {}) as Record<string, any>;
+    const tableParams = _.omit(_.get(req, "query", {}), ["alias"]) as Record<string, any>;
+    const useAlias = String(_.get(req, "query.alias", "true")).toLowerCase() !== "false";
 
     const missingParams: string[] = [];
-    const tableToRef: Record<string, string> = {};
     _.forEach(fromList, (entry: any) => {
         const table = _.get(entry, "table");
         const ref = tableParams[table];
         if (!_.isString(ref) || _.isEmpty(ref)) {
             missingParams.push(table);
-        } else {
-            tableToRef[table] = ref;
         }
     });
     if (!_.isEmpty(missingParams)) {
@@ -275,13 +273,37 @@ export const buildSqlQuery = async (req: Request, query: string) => {
         throw obsrvError("", "DATA_OUT_MISSING_TABLE_PARAM", errorMsg, "BAD_REQUEST", 400);
     }
 
-    // Verify each mapped datasource_ref exists in postgres.
-    const datasourceRefs = _.uniq(_.values(tableToRef));
-    const existing = await datasetService.getExistingDatasourceRefs(datasourceRefs);
-    const notFound = _.difference(datasourceRefs, _.map(existing, "datasource_ref"));
-    if (!_.isEmpty(notFound)) {
-        throw obsrvError("", "DATASOURCE_NOT_FOUND", `Datasource(s) not found: ${notFound.join(", ")}`, "NOT_FOUND", 404);
+    const tableToRef: Record<string, string> = {};
+
+    if (useAlias) {
+        const aliases = _.uniq(_.map(fromList, entry => tableParams[_.get(entry, "table")]));
+        const rows = await datasetService.getDatasourceRefsByAlias(aliases);
+        const aliasToRef = _.fromPairs(_.map(rows, r => [r.datasource, r.datasource_ref]));
+
+        const notFound = _.filter(aliases, alias => !aliasToRef[alias]);
+        if (!_.isEmpty(notFound)) {
+            throw obsrvError("", "DATASOURCE_NOT_FOUND", `Datasource(s) not found: ${notFound.join(", ")}`, "NOT_FOUND", 404);
+        }
+
+        _.forEach(fromList, (entry: any) => {
+            const table = _.get(entry, "table");
+            tableToRef[table] = aliasToRef[tableParams[table]];
+        });
+    } else {
+        _.forEach(fromList, (entry: any) => {
+            const table = _.get(entry, "table");
+            tableToRef[table] = tableParams[table];
+        });
+
+        const datasourceRefs = _.uniq(_.values(tableToRef));
+        const existing = await datasetService.getExistingDatasourceRefs(datasourceRefs);
+        const notFound = _.difference(datasourceRefs, _.map(existing, "datasource_ref"));
+        if (!_.isEmpty(notFound)) {
+            throw obsrvError("", "DATASOURCE_NOT_FOUND", `Datasource(s) not found: ${notFound.join(", ")}`, "NOT_FOUND", 404);
+        }
     }
+
+    const datasourceRefs = _.uniq(_.values(tableToRef));
 
     // Verify each mapped datasource_ref load status in Druid.
     const msgid = _.get(req, "body.params.msgid");

--- a/api-service/src/controllers/DataOut/QueryValidator.ts
+++ b/api-service/src/controllers/DataOut/QueryValidator.ts
@@ -252,9 +252,67 @@ const setDatasourceRef = async (datasetId: string, payload: any): Promise<any> =
     return true;
 }
 
+// Collect every CTE-declared name anywhere in the AST. These are local aliases
+// (WITH <name> AS ...), not datasources, so they must not be treated as tables.
+const collectCteNames = (node: any, acc: Set<string> = new Set()): Set<string> => {
+    if (_.isArray(node)) {
+        node.forEach((n) => collectCteNames(n, acc));
+        return acc;
+    }
+    if (!_.isObject(node)) return acc;
+    const withClause: any = _.get(node, "with");
+    if (_.isArray(withClause)) {
+        withClause.forEach((cte: any) => {
+            const name = _.get(cte, "name.value") || _.get(cte, "name");
+            if (_.isString(name)) acc.add(name);
+        });
+    }
+    _.forEach(node, (value) => collectCteNames(value, acc));
+    return acc;
+};
+
+// Recursively collect every FROM entry that references a real table name across
+// the whole AST: FROM-clause tables at any depth, derived-table subqueries, plus
+// tables inside CTE bodies, UNION/set-op branches, and WHERE/SELECT subqueries.
+// CTE-declared names are skipped so they are not demanded as table params.
+const collectTableEntries = (node: any, cteNames: Set<string>, acc: any[] = []): any[] => {
+    if (_.isArray(node)) {
+        node.forEach((n) => collectTableEntries(n, cteNames, acc));
+        return acc;
+    }
+    if (!_.isObject(node)) return acc;
+    const fromArr = _.get(node, "from");
+    if (_.isArray(fromArr)) {
+        _.forEach(fromArr, (entry: any) => {
+            const subquery = _.get(entry, "expr.ast");
+            if (subquery) {
+                collectTableEntries(subquery, cteNames, acc);
+                return;
+            }
+            const table = _.get(entry, "table");
+            if (_.isString(table) && !cteNames.has(table)) acc.push(entry);
+        });
+    }
+    // Walk every other key (with/_next/where/columns/...) to reach nested selects,
+    // but skip `from` to avoid re-visiting the entries handled above.
+    _.forEach(node, (value, key) => {
+        if (key !== "from") collectTableEntries(value, cteNames, acc);
+    });
+    return acc;
+};
+
 export const buildSqlQuery = async (req: Request, query: string) => {
-    const ast: any = parser.astify(query, { database: "postgresql" });
-    const fromList = _.castArray(_.get(ast, "from", [])).filter(Boolean);
+    let ast: any;
+    try {
+        ast = parser.astify(query, { database: "postgresql" });
+    } catch (error: any) {
+        logger.warn({ apiId, message: "SQL parse failed", error: error?.message });
+        throw obsrvError("", "DATA_OUT_INVALID_QUERY", "Invalid SQL query", "BAD_REQUEST", 400);
+    }
+    if (_.isArray(ast)) {
+        throw obsrvError("", "DATA_OUT_INVALID_QUERY", "Only a single SQL statement is supported", "BAD_REQUEST", 400);
+    }
+    const fromList = collectTableEntries(ast, collectCteNames(ast));
     const tableParams = _.omit(_.get(req, "query", {}), ["alias"]) as Record<string, any>;
     const useAlias = String(_.get(req, "query.alias", "true")).toLowerCase() !== "false";
 

--- a/api-service/src/controllers/DataOut/QueryValidator.ts
+++ b/api-service/src/controllers/DataOut/QueryValidator.ts
@@ -1,3 +1,4 @@
+import { Request } from "express";
 import { IQueryTypeRules } from "../../types/QueryModels";
 import { queryRules } from "./QueryRules";
 import * as _ from "lodash";
@@ -8,6 +9,7 @@ import { druidHttpService, getDatasourceListFromDruid } from "../../connections/
 import { apiId } from "./DataOutController";
 import { Parser } from "node-sql-parser";
 import { obsrvError } from "../../types/ObsrvError";
+import { datasetService } from "../../services/DatasetService";
 const parser = new Parser();
 
 const momentFormat = "YYYY-MM-DD HH:MM:SS";
@@ -249,3 +251,54 @@ const setDatasourceRef = async (datasetId: string, payload: any): Promise<any> =
     }
     return true;
 }
+
+export const buildSqlQuery = async (req: Request, query: string) => {
+    const ast: any = parser.astify(query, { database: "postgresql" });
+    const fromList = _.castArray(_.get(ast, "from", [])).filter(Boolean);
+    const tableParams = _.get(req, "query", {}) as Record<string, any>;
+
+    const missingParams: string[] = [];
+    const tableToRef: Record<string, string> = {};
+    _.forEach(fromList, (entry: any) => {
+        const table = _.get(entry, "table");
+        const ref = tableParams[table];
+        if (!_.isString(ref) || _.isEmpty(ref)) {
+            missingParams.push(table);
+        } else {
+            tableToRef[table] = ref;
+        }
+    });
+    if (!_.isEmpty(missingParams)) {
+        const logMsg = `Missing query param(s) for table(s): ${_.uniq(missingParams).join(", ")}`;
+        const errorMsg = "Invalid request: table mapping parameter is missing.";
+        logger.error({ apiId, message: logMsg });
+        throw obsrvError("", "DATA_OUT_MISSING_TABLE_PARAM", errorMsg, "BAD_REQUEST", 400);
+    }
+
+    // Verify each mapped datasource_ref exists in postgres.
+    const datasourceRefs = _.uniq(_.values(tableToRef));
+    const existing = await datasetService.getExistingDatasourceRefs(datasourceRefs);
+    const notFound = _.difference(datasourceRefs, _.map(existing, "datasource_ref"));
+    if (!_.isEmpty(notFound)) {
+        throw obsrvError("", "DATASOURCE_NOT_FOUND", `Datasource(s) not found: ${notFound.join(", ")}`, "NOT_FOUND", 404);
+    }
+
+    // Verify each mapped datasource_ref load status in Druid.
+    const msgid = _.get(req, "body.params.msgid");
+    for (const ref of datasourceRefs) {
+        await checkSupervisorAvailability(ref, req.body, msgid);
+    }
+
+    // Verify each mapped datasource_ref exists in Druid.
+    const druidDatasources = await getDatasourceListFromDruid();
+    const notInDruid = _.difference(datasourceRefs, druidDatasources.data);
+    if (!_.isEmpty(notInDruid)) {
+        throw obsrvError("", "DATASOURCE_NOT_FOUND", `Datasource(s) not available for querying: ${notInDruid.join(", ")}`, "NOT_FOUND", 404);
+    }
+
+    // Replace table names with the param values and emit SQL.
+    _.forEach(fromList, (entry: any) => { entry.table = tableToRef[entry.table]; });
+    const rewrittenQuery = parser.sqlify(ast, { database: "postgresql" }).replace(/`/g, "\"");
+    _.set(req, "body.query", rewrittenQuery);
+    return rewrittenQuery;
+};

--- a/api-service/src/controllers/DatasetRead/DatasetRead.ts
+++ b/api-service/src/controllers/DatasetRead/DatasetRead.ts
@@ -82,8 +82,9 @@ const readDataset = async (datasetId: string, attributes: string[]): Promise<any
     const api_version = _.get(dataset, "api_version")
     const datasetConfigs: any = {}
     const transformations_config = await datasetService.getTransformations(datasetId, ["field_key", "transformation_function", "mode", "metadata"])
-    const datasourceConfig = await Datasource.findOne({ where: { dataset_id: datasetId, is_primary: true, type: "druid" }, attributes: ["datasource"], raw: true })
+    const datasourceConfig = await Datasource.findOne({ where: { dataset_id: datasetId, is_primary: true, type: "druid" }, attributes: ["datasource", "ingestion_spec"], raw: true })
     datasetConfigs["alias"] = _.get(datasourceConfig, "datasource")
+    datasetConfigs["ingestion_spec"] = _.get(datasourceConfig, "ingestion_spec")
     if (api_version !== "v2") {
         datasetConfigs["transformations_config"] = _.map(transformations_config, (config) => {
             const section: any = _.get(config, "metadata.section") || _.get(config, "transformation_function.category");

--- a/api-service/src/controllers/DatasetRead/DatasetRead.ts
+++ b/api-service/src/controllers/DatasetRead/DatasetRead.ts
@@ -82,7 +82,7 @@ const readDataset = async (datasetId: string, attributes: string[]): Promise<any
     const api_version = _.get(dataset, "api_version")
     const datasetConfigs: any = {}
     const transformations_config = await datasetService.getTransformations(datasetId, ["field_key", "transformation_function", "mode", "metadata"])
-    const datasourceConfig = await Datasource.findOne({ where: { dataset_id: datasetId, is_primary: true, type: "druid" }, attributes: ["datasource", "ingestion_spec"], raw: true })
+    const datasourceConfig = await Datasource.findOne({ where: { dataset_id: datasetId, is_primary: true, type: "druid", status: "Live" }, attributes: ["datasource", "ingestion_spec"], raw: true })
     datasetConfigs["alias"] = _.get(datasourceConfig, "datasource")
     datasetConfigs["ingestion_spec"] = _.get(datasourceConfig, "ingestion_spec")
     if (api_version !== "v2") {

--- a/api-service/src/controllers/DatasourceList/DatasourceList.ts
+++ b/api-service/src/controllers/DatasourceList/DatasourceList.ts
@@ -15,7 +15,7 @@ export const errorCode = "DATASOURCES_LIST_FAILURE"
 const liveDatasourceStatus = ["Live", "Retired"]
 const draftDatasourceStatus = ["Draft"]
 const defaultLiveFields = ["dataset_id", "datasource", "type", "status", "id", "created_by", "updated_by", "created_date", "updated_date"]
-const defaultDraftFields = ["id", "dataset_id", "name", "type", "status", "created_by", "updated_by", "created_date", "updated_date"]
+const defaultDraftFields = ["id", "dataset_id", "type", "status", "created_by", "updated_by", "created_date", "updated_date"]
 const liveModelFields = _.keys(Datasource.getAttributes())
 const draftModelFields = _.keys(DatasourceDraft.getAttributes())
 

--- a/api-service/src/controllers/DatasourceList/DatasourceList.ts
+++ b/api-service/src/controllers/DatasourceList/DatasourceList.ts
@@ -12,6 +12,10 @@ export const apiId = "api.datasources.list"
 export const errorCode = "DATASOURCES_LIST_FAILURE"
 const liveDatasourceStatus = ["Live", "Retired"]
 const draftDatasourceStatus = ["Draft"]
+const defaultLiveFields = ["dataset_id", "datasource", "type", "status", "id", "created_by", "updated_by", "created_date", "updated_date"]
+const defaultDraftFields = ["id", "dataset_id", "name", "type", "status", "created_by", "updated_by", "created_date", "updated_date"]
+const allowedLiveFields = [...defaultLiveFields, "ingestion_spec", "datasource_ref", "retention_period", "archival_policy", "purge_policy", "backup_config", "published_date", "metadata"]
+const allowedDraftFields = [...defaultDraftFields, "ingestion_spec", "datasource_ref", "retention_period", "archival_policy", "purge_policy", "backup_config", "metadata"]
 
 const getDatasourceList = async (req: Request, res: Response) => {
 
@@ -29,13 +33,20 @@ const getDatasourceList = async (req: Request, res: Response) => {
 
 const listDatasources = async (request: Record<string, any>): Promise<Record<string, any>> => {
 
-    const { filters = {} } = request || {};
+    const { filters = {}, fields = [] } = request || {};
+    const requestedFields = _.isArray(fields) ? fields : _.compact([fields])
+    const invalidFields = _.difference(requestedFields, _.union(allowedLiveFields, allowedDraftFields))
+    if (!_.isEmpty(invalidFields)) {
+        throw obsrvError("", "DATASOURCE_LIST_INPUT_INVALID", `The specified fields [${invalidFields}] in the datasource cannot be found`, "BAD_REQUEST", 400)
+    }
+    const liveFields = _.union(defaultLiveFields, _.intersection(requestedFields, allowedLiveFields))
+    const draftFields = _.union(defaultDraftFields, _.intersection(requestedFields, allowedDraftFields))
     const dsStatus = _.get(filters, "status");
     const status = _.isArray(dsStatus) ? dsStatus : _.compact([dsStatus])
     const draftFilters = _.set(_.cloneDeep(filters), "status", _.isEmpty(status) ? draftDatasourceStatus : _.intersection(status, draftDatasourceStatus));
     const liveFilters = _.set(_.cloneDeep(filters), "status", _.isEmpty(status) ? liveDatasourceStatus : _.intersection(status, liveDatasourceStatus));
-    const liveDatasourceList = await datasetService.findDatasources(liveFilters, ["dataset_id", "datasource", "type", "status", "id", "type", "created_by", "updated_by", "created_date", "updated_date"]);
-    const draftDatasourceList = await datasetService.findDraftDatasources(draftFilters, ["id", "dataset_id","name", "type", "status", "created_by", "updated_by", "created_date", "updated_date"]);
+    const liveDatasourceList = await datasetService.findDatasources(liveFilters, liveFields);
+    const draftDatasourceList = await datasetService.findDraftDatasources(draftFilters, draftFields);
     return _.compact(_.concat(liveDatasourceList, draftDatasourceList));
 
 }

--- a/api-service/src/controllers/DatasourceList/DatasourceList.ts
+++ b/api-service/src/controllers/DatasourceList/DatasourceList.ts
@@ -7,6 +7,8 @@ import httpStatus from "http-status";
 import { ResponseHandler } from "../../helpers/ResponseHandler";
 import logger from "../../logger";
 import { datasetService } from "../../services/DatasetService";
+import { Datasource } from "../../models/Datasource";
+import { DatasourceDraft } from "../../models/DatasourceDraft";
 
 export const apiId = "api.datasources.list"
 export const errorCode = "DATASOURCES_LIST_FAILURE"
@@ -14,8 +16,8 @@ const liveDatasourceStatus = ["Live", "Retired"]
 const draftDatasourceStatus = ["Draft"]
 const defaultLiveFields = ["dataset_id", "datasource", "type", "status", "id", "created_by", "updated_by", "created_date", "updated_date"]
 const defaultDraftFields = ["id", "dataset_id", "name", "type", "status", "created_by", "updated_by", "created_date", "updated_date"]
-const allowedLiveFields = [...defaultLiveFields, "ingestion_spec", "datasource_ref", "retention_period", "archival_policy", "purge_policy", "backup_config", "published_date", "metadata"]
-const allowedDraftFields = [...defaultDraftFields, "ingestion_spec", "datasource_ref", "retention_period", "archival_policy", "purge_policy", "backup_config", "metadata"]
+const liveModelFields = _.keys(Datasource.getAttributes())
+const draftModelFields = _.keys(DatasourceDraft.getAttributes())
 
 const getDatasourceList = async (req: Request, res: Response) => {
 
@@ -34,13 +36,17 @@ const getDatasourceList = async (req: Request, res: Response) => {
 const listDatasources = async (request: Record<string, any>): Promise<Record<string, any>> => {
 
     const { filters = {}, fields = [] } = request || {};
-    const requestedFields = _.isArray(fields) ? fields : _.compact([fields])
-    const invalidFields = _.difference(requestedFields, _.union(allowedLiveFields, allowedDraftFields))
+    const allowedFields = _.union(liveModelFields, draftModelFields, defaultLiveFields, defaultDraftFields)
+    const requestedFields = _.uniq(_.isArray(fields) ? fields : _.compact([fields]))
+    if (_.size(requestedFields) > _.size(allowedFields)) {
+        throw obsrvError("", "DATASOURCE_LIST_INPUT_INVALID", "Fields array length exceeds the allowed limit", "BAD_REQUEST", 400)
+    }
+    const invalidFields = _.difference(requestedFields, allowedFields)
     if (!_.isEmpty(invalidFields)) {
         throw obsrvError("", "DATASOURCE_LIST_INPUT_INVALID", `The specified fields [${invalidFields}] in the datasource cannot be found`, "BAD_REQUEST", 400)
     }
-    const liveFields = _.union(defaultLiveFields, _.intersection(requestedFields, allowedLiveFields))
-    const draftFields = _.union(defaultDraftFields, _.intersection(requestedFields, allowedDraftFields))
+    const liveFields = _.union(defaultLiveFields, _.intersection(requestedFields, liveModelFields))
+    const draftFields = _.union(defaultDraftFields, _.intersection(requestedFields, draftModelFields))
     const dsStatus = _.get(filters, "status");
     const status = _.isArray(dsStatus) ? dsStatus : _.compact([dsStatus])
     const draftFilters = _.set(_.cloneDeep(filters), "status", _.isEmpty(status) ? draftDatasourceStatus : _.intersection(status, draftDatasourceStatus));

--- a/api-service/src/controllers/DatasourceList/DatasourceList.ts
+++ b/api-service/src/controllers/DatasourceList/DatasourceList.ts
@@ -37,10 +37,10 @@ const listDatasources = async (request: Record<string, any>): Promise<Record<str
 
     const { filters = {}, fields = [] } = request || {};
     const allowedFields = _.union(liveModelFields, draftModelFields, defaultLiveFields, defaultDraftFields)
-    const requestedFields = _.uniq(_.isArray(fields) ? fields : _.compact([fields]))
-    if (_.size(requestedFields) > _.size(allowedFields)) {
+    if (_.isArray(fields) && fields.length > allowedFields.length) {
         throw obsrvError("", "DATASOURCE_LIST_INPUT_INVALID", "Fields array length exceeds the allowed limit", "BAD_REQUEST", 400)
     }
+    const requestedFields = _.uniq(_.isArray(fields) ? fields : _.compact([fields]))
     const invalidFields = _.difference(requestedFields, allowedFields)
     if (!_.isEmpty(invalidFields)) {
         throw obsrvError("", "DATASOURCE_LIST_INPUT_INVALID", `The specified fields [${invalidFields}] in the datasource cannot be found`, "BAD_REQUEST", 400)

--- a/api-service/src/controllers/DatasourceList/RequestValidationSchema.json
+++ b/api-service/src/controllers/DatasourceList/RequestValidationSchema.json
@@ -48,6 +48,19 @@
               }
             },
             "additionalProperties": false
+          },
+          "fields": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string"
+              }
+            ]
           }
         },
         "additionalProperties": false

--- a/api-service/src/models/Datasource.ts
+++ b/api-service/src/models/Datasource.ts
@@ -58,6 +58,15 @@ export const Datasource = sequelize.define("datasources", {
     metadata: {
         type: DataTypes.JSON,
         defaultValue: {}
+    },
+    version: {
+        type: DataTypes.INTEGER
+    },
+    is_primary: {
+        type: DataTypes.BOOLEAN
+    },
+    name: {
+        type: DataTypes.STRING
     }
 }, {
     tableName: "datasources",

--- a/api-service/src/models/DatasourceDraft.ts
+++ b/api-service/src/models/DatasourceDraft.ts
@@ -55,6 +55,9 @@ export const DatasourceDraft = sequelize.define("datasources_draft", {
     metadata: {
         type: DataTypes.JSON,
         defaultValue: { "aggregated": false, "granularity": "day" }
+    },
+    published_date: {
+        type: DataTypes.TIME
     }
 }, {
     tableName: "datasources_draft",

--- a/api-service/src/routes/Router.ts
+++ b/api-service/src/routes/Router.ts
@@ -40,7 +40,7 @@ import getDatasourceList from "../controllers/DatasourceList/DatasourceList";
 export const router = express.Router();
 
 router.post("/data/in/:dataset_id", setDataToRequestObject("api.data.in"), onRequest({ entity: Entity.Data_in }), telemetryAuditStart({action: telemetryActions.ingestEvents, operationType: OperationType.CREATE}), checkRBAC.handler(), dataIn);
-router.post("/data/query/:dataset_id", setDataToRequestObject("api.data.out"), onRequest({ entity: Entity.Data_out }), checkRBAC.handler(), telemetryLogStart({action: telemetryActions.sqlQuery, operationType: OperationType.CREATE}), checkRBAC.handler(), dataOut);
+router.post("/data/query{/:dataset_id}", setDataToRequestObject("api.data.out"), onRequest({ entity: Entity.Data_out }), checkRBAC.handler(), telemetryLogStart({action: telemetryActions.sqlQuery, operationType: OperationType.CREATE}), checkRBAC.handler(), dataOut);
 router.post("/datasets/create", setDataToRequestObject("api.datasets.create"), onRequest({ entity: Entity.Management }),telemetryAuditStart({action: telemetryActions.createDataset, operationType: OperationType.CREATE}), checkRBAC.handler(),DatasetCreate)
 router.patch("/datasets/update", setDataToRequestObject("api.datasets.update"), onRequest({ entity: Entity.Management }),telemetryAuditStart({action: telemetryActions.updateDataset, operationType: OperationType.UPDATE}), checkRBAC.handler(), DatasetUpdate)
 router.get("/datasets/read/:dataset_id", setDataToRequestObject("api.datasets.read"), onRequest({ entity: Entity.Management }), telemetryAuditStart({action: telemetryActions.readDataset, operationType: OperationType.GET}), checkRBAC.handler(), DatasetRead)

--- a/api-service/src/services/DatasetService.ts
+++ b/api-service/src/services/DatasetService.ts
@@ -132,7 +132,7 @@ class DatasetService {
 
     getExistingDatasourceRefs = async (datasourceRefs: string[]): Promise<Record<string, any>[]> => {
         return Datasource.findAll({
-            where: { datasource_ref: { [Op.in]: datasourceRefs } },
+            where: { datasource_ref: { [Op.in]: datasourceRefs }, status: "Live" },
             attributes: ["datasource_ref"],
             raw: true
         }) as unknown as Record<string, any>[];
@@ -140,7 +140,7 @@ class DatasetService {
 
     getDatasourceRefsByAlias = async (aliases: string[]): Promise<Record<string, any>[]> => {
         return Datasource.findAll({
-            where: { datasource: { [Op.in]: aliases } },
+            where: { datasource: { [Op.in]: aliases }, status: "Live" },
             attributes: ["datasource", "datasource_ref"],
             raw: true
         }) as unknown as Record<string, any>[];

--- a/api-service/src/services/DatasetService.ts
+++ b/api-service/src/services/DatasetService.ts
@@ -138,6 +138,14 @@ class DatasetService {
         }) as unknown as Record<string, any>[];
     }
 
+    getDatasourceRefsByAlias = async (aliases: string[]): Promise<Record<string, any>[]> => {
+        return Datasource.findAll({
+            where: { datasource: { [Op.in]: aliases } },
+            attributes: ["datasource", "datasource_ref"],
+            raw: true
+        }) as unknown as Record<string, any>[];
+    }
+
     updateDatasource = async (payload: Record<string, any>, where: Record<string, any>): Promise<Record<string, any>> => {
         return Datasource.update(payload, { where });
     }

--- a/api-service/src/services/DatasetService.ts
+++ b/api-service/src/services/DatasetService.ts
@@ -130,6 +130,14 @@ class DatasetService {
         }
     }
 
+    getExistingDatasourceRefs = async (datasourceRefs: string[]): Promise<Record<string, any>[]> => {
+        return Datasource.findAll({
+            where: { datasource_ref: { [Op.in]: datasourceRefs } },
+            attributes: ["datasource_ref"],
+            raw: true
+        }) as unknown as Record<string, any>[];
+    }
+
     updateDatasource = async (payload: Record<string, any>, where: Record<string, any>): Promise<Record<string, any>> => {
         return Datasource.update(payload, { where });
     }


### PR DESCRIPTION
# Summary

This document provides a detailed summary of the architectural and code changes implemented in the `obsrv-api-service` for SQL query parameter validation, datasource verification, and limit enforcement.

---

## 1. Table Param Mapping and Verification Logic

### Why is this done?
In the direct SQL query endpoint (`/v2/data/query`), queries are written against logical table names (e.g. `SELECT * FROM table1 JOIN table2`). However, the database engine (Druid) refers to physical datasources using system-generated unique reference tags (e.g. `test_events`, `user-data_events`).

To map these securely and correctly:
1. The client must pass mapping parameters in the URL query string (e.g. `?table1=ref1&table2=ref2`).
2. The service scans the SQL abstract syntax tree (AST) to identify all tables queried.
3. For each table, it matches the logical table name to the physical `datasource_ref` from the request params.
4. It checks Postgres to confirm that the mapped reference exists as a registered datasource.
5. It checks Druid to verify the datasource segments are fully loaded ($100\%$ availability) and that the datasource exists in Druid.
6. Finally, it rewrites the table names in the SQL AST with the resolved physical refs before sending the query.

---

## 2. SQL Limit Parsing and Capping Logic

### Why is this done?
To prevent huge query results from overloading the system, causing memory exhaustion (OOM), or slowing down response times, the service enforces a maximum row limit (`maxResultRowLimit`, currently defaulted to 5000 and is env configurable).

The logic acts as follows:
* **AST Parsing**: The service astifies the SQL query using `node-sql-parser`.
* **Adding Default Limit**: If no `LIMIT` clause is present, a default limit of `5000` is appended.
* **Capping User-defined Limit**: If a `LIMIT` clause exists, the code checks if the requested limit exceeds `maxResultRowLimit`. It correctly handles different syntax variations:
  - Standard limit: `LIMIT <userLimit>`
  - If the user-defined limit is $> 5000$, it is capped exactly to `5000`.
* **Safe Fallback**: If the query contains complex features that the parser cannot parse, the service catches the error and falls back to regex. If no `LIMIT` keyword is present, it appends ` LIMIT 5000` to the query string to prevent unrestricted queries, otherwise executing the query as-is to avoid breaking complex queries.

---

## 3. Positive and Negative Scenarios

### Table Parameter and Datasource Verification Scenarios

| Scenario | Details | Expected Behavior / Status | Response Payload / Error Message |
| :--- | :--- | :--- | :--- |
| **Positive Scenario** | All tables mapped; refs exist in Postgres and Druid ($100\%$ loaded). | `200 OK` (Success) | Standard query results: `{ "status": 200, "data": [...] }` |
| **Missing Mappings** | SQL contains a table not mapped in query parameters. | `400 Bad Request` | `{ "params": { "status": "FAILED" }, "error": { "code": "DATA_OUT_MISSING_TABLE_PARAM", "message": "Invalid request: table mapping parameter is missing." } }` *(Logged: Missing query param(s) for table(s): table2)* |
| **Postgres Lookup Failure** | Mapped `datasource_ref` does not exist in Postgres `datasources`. | `404 Not Found` | `{ "params": { "status": "FAILED" }, "error": { "code": "DATASOURCE_NOT_FOUND", "message": "Datasource(s) not found: ref1" } }` |
| **Segments Not Published** | Mapped `datasource_ref` load status is missing in Druid coordinator. | `404 Not Found` | `{ "params": { "status": "FAILED" }, "error": { "code": "DATASOURCE_NOT_AVAILABLE", "message": "Datasource not available for querying" } }` *(Logged: Segments not published to the metadata store yet)* |
| **Segments Loading** | Mapped `datasource_ref` load status is less than $100\%$ in Druid coordinator. | `416 Range Not Satisfiable` | `{ "params": { "status": "FAILED" }, "error": { "code": "DATASOURCE_NOT_FULLY_AVAILABLE", "message": "Data is still loading. Please try after some time." } }` *(Logged: Segments not fully published... current load: <progress>%)* |
| **Druid Lookup Failure** | Mapped `datasource_ref` is not found in Druid's active datasource list. | `404 Not Found` | `{ "params": { "status": "FAILED" }, "error": { "code": "DATASOURCE_NOT_FOUND", "message": "Datasource(s) not available for querying: ref1" } }` |

### SQL Limit Capping Scenarios

| Scenario | Input Query | Output Query / Behavior | Status |
| :--- | :--- | :--- | :--- |
| **No Limit Clause** | `SELECT * FROM table1` | `SELECT * FROM "ref1" LIMIT 5000` | `200 OK` |
| **Limit within Allowed Range** | `SELECT * FROM table1 LIMIT 10` | `SELECT * FROM "ref1" LIMIT 10` *(Left untouched)* | `200 OK` |
| **Limit Exceeding Range** | `SELECT * FROM table1 LIMIT 10000` | `SELECT * FROM "ref1" LIMIT 5000` *(Capped)* | `200 OK` |
| **Limit with Offset** | `SELECT * FROM table1 LIMIT 10000 OFFSET 5` | `SELECT * FROM "ref1" LIMIT 5000 OFFSET 5` *(Capped)* | `200 OK` |
| **Comma-separated Limit** | `SELECT * FROM table1 LIMIT 10, 10000` | `SELECT * FROM "ref1" LIMIT 10, 5000` *(Capped)* | `200 OK` |
| **Unparseable SQL (Fallback)** | `SELECT * FROM table1 WITH COMPLEX_FEATURES` | Regex fallback applies. Checks for presence of `LIMIT` keyword. Appends `LIMIT 5000` only if absent. | `200 OK` |

---

## 4. Refactoring and System Improvements

* **API Service**: Updated `parser.astify` and `parser.sqlify` in [QueryValidator.ts](file:///Users/jeraldjf/Documents/obsrv/obsrv-api-service/api-service/src/controllers/DataOut/QueryValidator.ts) to explicitly pass `{ database: "postgresql" }`. This prevents parser syntax errors when parsing ANSI/SQL-92 compliant queries containing double quotes around identifiers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Data query endpoint path updated to `/data/query{/:dataset_id}` (optional dataset id in the route).
  * Datasource list now supports `filters.fields` to request a customized set of datasource fields.
* **Bug Fixes**
  * SQL-based data queries now rewrite referenced tables to their mapped datasource references before execution, with improved handling when required mappings or datasource availability are missing.
* **Refactor**
  * Dataset read responses now include additional datasource metadata (`ingestion_spec`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->