### PR TITLE
#fix: superset sql wrapper with alias support

### DIFF
--- a/api-service/Dockerfile.dhi
+++ b/api-service/Dockerfile.dhi
@@ -1,0 +1,26 @@
+# DHI hardened build. Dev variant (shell + npm + toolchain) for install/build; minimal
+# shell-less non-root runtime. dataset-api compiles TS -> dist/ (tsc) and starts via plain
+# `node` — no shell/npm/ts-node needed at runtime (tsconfig has no path aliases, so no
+# tsconfig-paths at runtime either). Build from this directory: `docker build -f Dockerfile.dhi .`
+ARG BUILD_IMAGE=dhi.io/node:24-alpine3.24-dev
+ARG RUNTIME_IMAGE=dhi.io/node:24-alpine3.24
+
+# Stage 1 - build (tsc -> dist)
+FROM ${BUILD_IMAGE} AS build
+WORKDIR /opt/api-service
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+RUN rm -rf postman-collection \
+    && npm run build \
+    && npm prune --omit=dev
+
+# Stage 2 - runtime (minimal, shell-less, non-root)
+FROM ${RUNTIME_IMAGE}
+WORKDIR /opt/api-service
+COPY --chown=node:node --from=build /opt/api-service/dist ./dist
+COPY --chown=node:node --from=build /opt/api-service/node_modules ./node_modules
+COPY --chown=node:node --from=build /opt/api-service/package.json ./package.json
+USER node
+EXPOSE 3000
+CMD ["node", "dist/app.js"]

--- a/api-service/src/configs/Config.ts
+++ b/api-service/src/configs/Config.ts
@@ -37,7 +37,7 @@ export const config = {
     "prometheus": {
       "url": process.env.prometheus_url || "http://localhost:9090"
     },
-    "sql_query_alias_support": process.env.sql_query_alias_support || "true"
+    "sql_query_alias_support": process.env.sql_query_alias_support || "false"
   },
   "telemetry_service_config": {
     level: process.env.telemetry_log_level || "info",

--- a/api-service/src/configs/Config.ts
+++ b/api-service/src/configs/Config.ts
@@ -37,7 +37,7 @@ export const config = {
     "prometheus": {
       "url": process.env.prometheus_url || "http://localhost:9090"
     },
-    "sql_query_alias_check": process.env.sql_query_alias_check !== "false"
+    "sql_query_alias_support": process.env.sql_query_alias_support !== "false"
   },
   "telemetry_service_config": {
     level: process.env.telemetry_log_level || "info",

--- a/api-service/src/configs/Config.ts
+++ b/api-service/src/configs/Config.ts
@@ -37,7 +37,7 @@ export const config = {
     "prometheus": {
       "url": process.env.prometheus_url || "http://localhost:9090"
     },
-    "sql_query_alias_support": process.env.sql_query_alias_support !== "false"
+    "sql_query_alias_support": process.env.sql_query_alias_support || "true"
   },
   "telemetry_service_config": {
     level: process.env.telemetry_log_level || "info",

--- a/api-service/src/configs/Config.ts
+++ b/api-service/src/configs/Config.ts
@@ -36,7 +36,8 @@ export const config = {
     },
     "prometheus": {
       "url": process.env.prometheus_url || "http://localhost:9090"
-    }
+    },
+    "sql_query_alias_check": process.env.sql_query_alias_check !== "false"
   },
   "telemetry_service_config": {
     level: process.env.telemetry_log_level || "info",

--- a/api-service/src/controllers/DataOut/QueryValidator.ts
+++ b/api-service/src/controllers/DataOut/QueryValidator.ts
@@ -10,6 +10,7 @@ import { apiId } from "./DataOutController";
 import { Parser } from "node-sql-parser";
 import { obsrvError } from "../../types/ObsrvError";
 import { datasetService } from "../../services/DatasetService";
+import { collectCteNames, collectTableEntries } from "../../services/SqlQueryService";
 const parser = new Parser();
 
 const momentFormat = "YYYY-MM-DD HH:MM:SS";
@@ -251,55 +252,6 @@ const setDatasourceRef = async (datasetId: string, payload: any): Promise<any> =
     }
     return true;
 }
-
-// Collect every CTE-declared name anywhere in the AST. These are local aliases
-// (WITH <name> AS ...), not datasources, so they must not be treated as tables.
-const collectCteNames = (node: any, acc: Set<string> = new Set()): Set<string> => {
-    if (_.isArray(node)) {
-        node.forEach((n) => collectCteNames(n, acc));
-        return acc;
-    }
-    if (!_.isObject(node)) return acc;
-    const withClause: any = _.get(node, "with");
-    if (_.isArray(withClause)) {
-        withClause.forEach((cte: any) => {
-            const name = _.get(cte, "name.value") || _.get(cte, "name");
-            if (_.isString(name)) acc.add(name);
-        });
-    }
-    _.forEach(node, (value) => collectCteNames(value, acc));
-    return acc;
-};
-
-// Recursively collect every FROM entry that references a real table name across
-// the whole AST: FROM-clause tables at any depth, derived-table subqueries, plus
-// tables inside CTE bodies, UNION/set-op branches, and WHERE/SELECT subqueries.
-// CTE-declared names are skipped so they are not demanded as table params.
-const collectTableEntries = (node: any, cteNames: Set<string>, acc: any[] = []): any[] => {
-    if (_.isArray(node)) {
-        node.forEach((n) => collectTableEntries(n, cteNames, acc));
-        return acc;
-    }
-    if (!_.isObject(node)) return acc;
-    const fromArr = _.get(node, "from");
-    if (_.isArray(fromArr)) {
-        _.forEach(fromArr, (entry: any) => {
-            const subquery = _.get(entry, "expr.ast");
-            if (subquery) {
-                collectTableEntries(subquery, cteNames, acc);
-                return;
-            }
-            const table = _.get(entry, "table");
-            if (_.isString(table) && !cteNames.has(table)) acc.push(entry);
-        });
-    }
-    // Walk every other key (with/_next/where/columns/...) to reach nested selects,
-    // but skip `from` to avoid re-visiting the entries handled above.
-    _.forEach(node, (value, key) => {
-        if (key !== "from") collectTableEntries(value, cteNames, acc);
-    });
-    return acc;
-};
 
 export const buildSqlQuery = async (req: Request, query: string) => {
     let ast: any;

--- a/api-service/src/controllers/DatasourceList/DatasourceList.ts
+++ b/api-service/src/controllers/DatasourceList/DatasourceList.ts
@@ -8,7 +8,7 @@ import { ResponseHandler } from "../../helpers/ResponseHandler";
 import logger from "../../logger";
 import { datasetService } from "../../services/DatasetService";
 import { Datasource } from "../../models/Datasource";
-import { DatasourceDraft } from "../../models/DatasourceDraft";
+import TableDraft from "../../models/Table";
 
 export const apiId = "api.datasources.list"
 export const errorCode = "DATASOURCES_LIST_FAILURE"
@@ -17,7 +17,7 @@ const draftDatasourceStatus = ["Draft"]
 const defaultLiveFields = ["dataset_id", "datasource", "type", "status", "id", "created_by", "updated_by", "created_date", "updated_date"]
 const defaultDraftFields = ["id", "dataset_id", "type", "status", "created_by", "updated_by", "created_date", "updated_date"]
 const liveModelFields = _.keys(Datasource.getAttributes())
-const draftModelFields = _.keys(DatasourceDraft.getAttributes())
+const draftModelFields = _.keys(TableDraft.getAttributes())
 
 const getDatasourceList = async (req: Request, res: Response) => {
 

--- a/api-service/src/controllers/QueryWrapper/SqlQueryWrapper.ts
+++ b/api-service/src/controllers/QueryWrapper/SqlQueryWrapper.ts
@@ -5,61 +5,15 @@ import logger from "../../logger";
 import { ResponseHandler } from "../../helpers/ResponseHandler";
 import { ErrorObject } from "../../types/ResponseModel";
 import { druidHttpService } from "../../connections/druidConnection";
-import { getDatasourceList } from "../../services/DatasourceService";
+import { getDatasourceList, getLiveDatasourcesByNames } from "../../services/DatasourceService";
 import { AxiosResponse } from "axios";
 import { Parser } from "node-sql-parser";
-import { Op } from "sequelize";
-import { Datasource } from "../../models/Datasource";
+import { collectCteNames, collectTableEntries } from "../../services/SqlQueryService";
 
 const apiId = "api.obsrv.data.sql-query";
 const errorCode = "SQL_QUERY_FAILURE"
-export const result_data = {"data": {}};
+export const result_data = { "data": {} };
 const parser = new Parser();
-
-// Collect every CTE-declared name anywhere in the AST. These are local aliases
-// (WITH <name> AS ...), not datasources, so they must never be treated as tables.
-const collectCteNames = (node: any, acc: Set<string> = new Set()): Set<string> => {
-    if (_.isArray(node)) {
-        node.forEach((n) => collectCteNames(n, acc));
-        return acc;
-    }
-    if (!_.isObject(node)) return acc;
-    const withClause: any = _.get(node, "with");
-    if (_.isArray(withClause)) {
-        withClause.forEach((cte: any) => {
-            const name = _.get(cte, "name.value") || _.get(cte, "name");
-            if (_.isString(name)) acc.add(name);
-        });
-    }
-    _.forEach(node, (value) => collectCteNames(value, acc));
-    return acc;
-};
-
-// Recursively collect every FROM entry that references a real table name across
-// the whole AST (nested selects, set-ops, CTE bodies), skipping CTE-declared names.
-const collectTableEntries = (node: any, cteNames: Set<string>, acc: any[] = []): any[] => {
-    if (_.isArray(node)) {
-        node.forEach((n) => collectTableEntries(n, cteNames, acc));
-        return acc;
-    }
-    if (!_.isObject(node)) return acc;
-    const fromArr = _.get(node, "from");
-    if (_.isArray(fromArr)) {
-        _.forEach(fromArr, (entry: any) => {
-            const subquery = _.get(entry, "expr.ast");
-            if (subquery) {
-                collectTableEntries(subquery, cteNames, acc);
-                return;
-            }
-            const table = _.get(entry, "table");
-            if (_.isString(table) && !cteNames.has(table)) acc.push(entry);
-        });
-    }
-    _.forEach(node, (value, key) => {
-        if (key !== "from") collectTableEntries(value, cteNames, acc);
-    });
-    return acc;
-};
 
 // Rewrites table names to datasource_refs ONLY when a name matches a datasource
 // alias that is not itself already a datasource_ref. Any other case (name already
@@ -89,18 +43,8 @@ const resolveDatasourceQuery = async (query: string, resmsgid?: string): Promise
             return query;
         }
 
-        // Single indexed lookup for all referenced names at once (alias OR ref).
-        const rows: any[] = await Datasource.findAll({
-            where: {
-                status: "Live",
-                [Op.or]: [
-                    { datasource_ref: { [Op.in]: tableNames } },
-                    { datasource: { [Op.in]: tableNames } },
-                ],
-            },
-            attributes: ["datasource", "datasource_ref"],
-            raw: true,
-        });
+        // Only hit Postgres once we know the query actually references tables.
+        const rows = await getLiveDatasourcesByNames(tableNames);
         if (_.isEmpty(rows)) {
             logger.warn({ apiId, resmsgid, tableNames, message: "No matching datasource/datasource_ref exists, passing query as-is" });
             return query;
@@ -198,14 +142,14 @@ const fetchDruidDataSources = async (): Promise<{ TABLE_NAME: string }[]> => {
 
 const isTableSchemaQuery = (sqlQuery?: string): boolean => {
     return (
-      sqlQuery
-        ?.trim()
-        .replace(/\s+/g, " ")
-        .toUpperCase() ===
-      "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'DRUID'"
+        sqlQuery
+            ?.trim()
+            .replace(/\s+/g, " ")
+            .toUpperCase() ===
+        "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'DRUID'"
     );
-  };
-  
+};
+
 
 const createMockAxiosResponse = (data: any): AxiosResponse => {
     return {

--- a/api-service/src/controllers/QueryWrapper/SqlQueryWrapper.ts
+++ b/api-service/src/controllers/QueryWrapper/SqlQueryWrapper.ts
@@ -107,11 +107,11 @@ export const sqlQuery = async (req: Request, res: Response) => {
             result = createMockAxiosResponse(dataSources);
         } else {
             let requestPayload = req.body;
-            if (config.query_api.sql_query_alias_check) {
+            if (config.query_api.sql_query_alias_support) {
                 const resolvedQuery = await resolveDatasourceQuery(query, resmsgid);
                 requestPayload = resolvedQuery === query ? req.body : { ...req.body, query: resolvedQuery };
             } else {
-                logger.info({ apiId, resmsgid, message: "sql_query_alias_check disabled, passing query as-is" });
+                logger.info({ apiId, resmsgid, message: "sql_query_alias_support disabled, passing query as-is" });
             }
             result = await druidHttpService.post(`${config.query_api.druid.sql_query_path}`, requestPayload, {
                 headers: { Authorization: authorization },

--- a/api-service/src/controllers/QueryWrapper/SqlQueryWrapper.ts
+++ b/api-service/src/controllers/QueryWrapper/SqlQueryWrapper.ts
@@ -51,8 +51,10 @@ const resolveDatasourceQuery = async (query: string, resmsgid?: string): Promise
         }
 
         const refSet = new Set(_.map(rows, "datasource_ref"));
-        const aliasToRef: Record<string, string> = {};
-        rows.forEach((r) => { if (r.datasource) aliasToRef[r.datasource] = r.datasource_ref; });
+        // Map (not a plain object) so table names that collide with Object.prototype
+        // keys (constructor, toString, ...) are only matched when actually present.
+        const aliasToRef = new Map<string, string>();
+        rows.forEach((r) => { if (r.datasource) aliasToRef.set(r.datasource, r.datasource_ref); });
 
         let changed = false;
         _.forEach(fromList, (entry: any) => {
@@ -61,7 +63,7 @@ const resolveDatasourceQuery = async (query: string, resmsgid?: string): Promise
                 logger.info({ apiId, resmsgid, table: name, message: `Table '${name}' already a datasource_ref, keeping as-is` });
                 return;
             }
-            const ref = aliasToRef[name];
+            const ref = aliasToRef.get(name);
             if (!ref) {                                // unknown -> keep
                 logger.warn({ apiId, resmsgid, table: name, message: `Table '${name}' is neither a datasource alias nor a datasource_ref, keeping as-is` });
                 return;
@@ -77,7 +79,10 @@ const resolveDatasourceQuery = async (query: string, resmsgid?: string): Promise
             return query;
         }
 
-        return parser.sqlify(ast, { database: "postgresql" }).replace(/`/g, "\"");
+        // postgresql dialect emits double-quoted identifiers, so no backtick
+        // post-processing is needed (a global replace could corrupt backticks
+        // inside string literals).
+        return parser.sqlify(ast, { database: "postgresql" });
     } catch (error: any) {
         // Never let resolution break querying — fall back to the original query.
         logger.warn({ apiId, resmsgid, message: "Datasource resolution skipped, passing query as-is", error: error?.message });
@@ -107,7 +112,7 @@ export const sqlQuery = async (req: Request, res: Response) => {
             result = createMockAxiosResponse(dataSources);
         } else {
             let requestPayload = req.body;
-            if (config.query_api.sql_query_alias_support) {
+            if (config.query_api.sql_query_alias_support === "true") {
                 const resolvedQuery = await resolveDatasourceQuery(query, resmsgid);
                 requestPayload = resolvedQuery === query ? req.body : { ...req.body, query: resolvedQuery };
             } else {

--- a/api-service/src/controllers/QueryWrapper/SqlQueryWrapper.ts
+++ b/api-service/src/controllers/QueryWrapper/SqlQueryWrapper.ts
@@ -7,10 +7,139 @@ import { ErrorObject } from "../../types/ResponseModel";
 import { druidHttpService } from "../../connections/druidConnection";
 import { getDatasourceList } from "../../services/DatasourceService";
 import { AxiosResponse } from "axios";
+import { Parser } from "node-sql-parser";
+import { Op } from "sequelize";
+import { Datasource } from "../../models/Datasource";
 
 const apiId = "api.obsrv.data.sql-query";
 const errorCode = "SQL_QUERY_FAILURE"
 export const result_data = {"data": {}};
+const parser = new Parser();
+
+// Collect every CTE-declared name anywhere in the AST. These are local aliases
+// (WITH <name> AS ...), not datasources, so they must never be treated as tables.
+const collectCteNames = (node: any, acc: Set<string> = new Set()): Set<string> => {
+    if (_.isArray(node)) {
+        node.forEach((n) => collectCteNames(n, acc));
+        return acc;
+    }
+    if (!_.isObject(node)) return acc;
+    const withClause: any = _.get(node, "with");
+    if (_.isArray(withClause)) {
+        withClause.forEach((cte: any) => {
+            const name = _.get(cte, "name.value") || _.get(cte, "name");
+            if (_.isString(name)) acc.add(name);
+        });
+    }
+    _.forEach(node, (value) => collectCteNames(value, acc));
+    return acc;
+};
+
+// Recursively collect every FROM entry that references a real table name across
+// the whole AST (nested selects, set-ops, CTE bodies), skipping CTE-declared names.
+const collectTableEntries = (node: any, cteNames: Set<string>, acc: any[] = []): any[] => {
+    if (_.isArray(node)) {
+        node.forEach((n) => collectTableEntries(n, cteNames, acc));
+        return acc;
+    }
+    if (!_.isObject(node)) return acc;
+    const fromArr = _.get(node, "from");
+    if (_.isArray(fromArr)) {
+        _.forEach(fromArr, (entry: any) => {
+            const subquery = _.get(entry, "expr.ast");
+            if (subquery) {
+                collectTableEntries(subquery, cteNames, acc);
+                return;
+            }
+            const table = _.get(entry, "table");
+            if (_.isString(table) && !cteNames.has(table)) acc.push(entry);
+        });
+    }
+    _.forEach(node, (value, key) => {
+        if (key !== "from") collectTableEntries(value, cteNames, acc);
+    });
+    return acc;
+};
+
+// Rewrites table names to datasource_refs ONLY when a name matches a datasource
+// alias that is not itself already a datasource_ref. Any other case (name already
+// a datasource_ref, name unknown, parse failure) returns the ORIGINAL query
+// string verbatim so nothing about the pydruid/Superset request is altered.
+const resolveDatasourceQuery = async (query: string, resmsgid?: string): Promise<string> => {
+    try {
+        if (!_.isString(query) || _.isEmpty(query)) return query;
+
+        let ast: any;
+        try {
+            ast = parser.astify(query, { database: "postgresql" });
+        } catch {
+            // node-sql-parser can't parse this SQL (Druid-specific syntax etc.) -> pass through untouched.
+            logger.info({ apiId, resmsgid, message: "Query not parseable for alias check, passing query as-is" });
+            return query;
+        }
+        if (_.isArray(ast)) {
+            logger.info({ apiId, resmsgid, message: "Multi-statement query, passing query as-is" });
+            return query; // multi-statement -> leave as-is
+        }
+
+        const fromList = collectTableEntries(ast, collectCteNames(ast));
+        const tableNames = _.uniq(_.map(fromList, (e) => e.table).filter(_.isString));
+        if (_.isEmpty(tableNames)) {
+            logger.info({ apiId, resmsgid, message: "No table references found, passing query as-is" });
+            return query;
+        }
+
+        // Single indexed lookup for all referenced names at once (alias OR ref).
+        const rows: any[] = await Datasource.findAll({
+            where: {
+                status: "Live",
+                [Op.or]: [
+                    { datasource_ref: { [Op.in]: tableNames } },
+                    { datasource: { [Op.in]: tableNames } },
+                ],
+            },
+            attributes: ["datasource", "datasource_ref"],
+            raw: true,
+        });
+        if (_.isEmpty(rows)) {
+            logger.warn({ apiId, resmsgid, tableNames, message: "No matching datasource/datasource_ref exists, passing query as-is" });
+            return query;
+        }
+
+        const refSet = new Set(_.map(rows, "datasource_ref"));
+        const aliasToRef: Record<string, string> = {};
+        rows.forEach((r) => { if (r.datasource) aliasToRef[r.datasource] = r.datasource_ref; });
+
+        let changed = false;
+        _.forEach(fromList, (entry: any) => {
+            const name = entry.table;
+            if (refSet.has(name)) {                    // already a datasource_ref -> keep
+                logger.info({ apiId, resmsgid, table: name, message: `Table '${name}' already a datasource_ref, keeping as-is` });
+                return;
+            }
+            const ref = aliasToRef[name];
+            if (!ref) {                                // unknown -> keep
+                logger.warn({ apiId, resmsgid, table: name, message: `Table '${name}' is neither a datasource alias nor a datasource_ref, keeping as-is` });
+                return;
+            }
+            entry.table = ref;                         // alias -> replace with datasource_ref
+            if (!entry.as || _.isEmpty(entry.as)) entry.as = name; // preserve name for column refs
+            changed = true;
+            logger.info({ apiId, resmsgid, alias: name, datasource_ref: ref, message: `Resolved alias '${name}' to datasource_ref '${ref}'` });
+        });
+
+        if (!changed) {                                // the only scenario we rewrite is alias->ref
+            logger.info({ apiId, resmsgid, message: "No alias to resolve, passing query as-is" });
+            return query;
+        }
+
+        return parser.sqlify(ast, { database: "postgresql" }).replace(/`/g, "\"");
+    } catch (error: any) {
+        // Never let resolution break querying — fall back to the original query.
+        logger.warn({ apiId, resmsgid, message: "Datasource resolution skipped, passing query as-is", error: error?.message });
+        return query;
+    }
+};
 
 export const sqlQuery = async (req: Request, res: Response) => {
     const resmsgid = _.get(res, "resmsgid");
@@ -33,7 +162,14 @@ export const sqlQuery = async (req: Request, res: Response) => {
             const dataSources = await fetchDruidDataSources();
             result = createMockAxiosResponse(dataSources);
         } else {
-            result = await druidHttpService.post(`${config.query_api.druid.sql_query_path}`, req.body, {
+            let requestPayload = req.body;
+            if (config.query_api.sql_query_alias_check) {
+                const resolvedQuery = await resolveDatasourceQuery(query, resmsgid);
+                requestPayload = resolvedQuery === query ? req.body : { ...req.body, query: resolvedQuery };
+            } else {
+                logger.info({ apiId, resmsgid, message: "sql_query_alias_check disabled, passing query as-is" });
+            }
+            result = await druidHttpService.post(`${config.query_api.druid.sql_query_path}`, requestPayload, {
                 headers: { Authorization: authorization },
             });
         }

--- a/api-service/src/services/DatasourceService.ts
+++ b/api-service/src/services/DatasourceService.ts
@@ -1,3 +1,4 @@
+import { Op } from "sequelize";
 import { Datasource } from "../models/Datasource";
 
 export const getDatasourceList = async (datasetId?: string, raw: boolean = false) => {
@@ -7,6 +8,22 @@ export const getDatasourceList = async (datasetId?: string, raw: boolean = false
     }
 
     return Datasource.findAll(query);
+};
+
+// Fetch Live datasources whose datasource_ref OR datasource (alias) matches any
+// of the given names. Used by the sql-query alias check to resolve table names.
+export const getLiveDatasourcesByNames = async (names: string[]): Promise<{ datasource: string; datasource_ref: string }[]> => {
+    return Datasource.findAll({
+        where: {
+            status: "Live",
+            [Op.or]: [
+                { datasource_ref: { [Op.in]: names } },
+                { datasource: { [Op.in]: names } },
+            ],
+        },
+        attributes: ["datasource", "datasource_ref"],
+        raw: true,
+    }) as any;
 };
 
 

--- a/api-service/src/services/SqlQueryService.ts
+++ b/api-service/src/services/SqlQueryService.ts
@@ -32,19 +32,14 @@ export const collectTableEntries = (node: any, cteNames: Set<string>, acc: any[]
     const fromArr = _.get(node, "from");
     if (_.isArray(fromArr)) {
         _.forEach(fromArr, (entry: any) => {
-            const subquery = _.get(entry, "expr.ast");
-            if (subquery) {
-                collectTableEntries(subquery, cteNames, acc);
-                return;
-            }
             const table = _.get(entry, "table");
             if (_.isString(table) && !cteNames.has(table)) acc.push(entry);
         });
     }
-    // Walk every other key (with/_next/where/columns/...) to reach nested selects,
-    // but skip `from` to avoid re-visiting the entries handled above.
-    _.forEach(node, (value, key) => {
-        if (key !== "from") collectTableEntries(value, cteNames, acc);
-    });
+    // Walk every key (including `from`) to reach nested selects wherever they
+    // live: derived tables (`expr.ast`), JOIN `ON` subqueries (`entry.on`),
+    // WHERE/SELECT subqueries, CTE bodies and set-op branches. FROM entries hold
+    // no nested `from` of their own, so real tables are never pushed twice.
+    _.forEach(node, (value) => collectTableEntries(value, cteNames, acc));
     return acc;
 };

--- a/api-service/src/services/SqlQueryService.ts
+++ b/api-service/src/services/SqlQueryService.ts
@@ -1,0 +1,50 @@
+import * as _ from "lodash";
+
+// Collect every CTE-declared name anywhere in the AST. These are local aliases
+// (WITH <name> AS ...), not datasources, so they must not be treated as tables.
+export const collectCteNames = (node: any, acc: Set<string> = new Set()): Set<string> => {
+    if (_.isArray(node)) {
+        node.forEach((n) => collectCteNames(n, acc));
+        return acc;
+    }
+    if (!_.isObject(node)) return acc;
+    const withClause: any = _.get(node, "with");
+    if (_.isArray(withClause)) {
+        withClause.forEach((cte: any) => {
+            const name = _.get(cte, "name.value") || _.get(cte, "name");
+            if (_.isString(name)) acc.add(name);
+        });
+    }
+    _.forEach(node, (value) => collectCteNames(value, acc));
+    return acc;
+};
+
+// Recursively collect every FROM entry that references a real table name across
+// the whole AST: FROM-clause tables at any depth, derived-table subqueries, plus
+// tables inside CTE bodies, UNION/set-op branches, and WHERE/SELECT subqueries.
+// CTE-declared names are skipped so they are not demanded as table params.
+export const collectTableEntries = (node: any, cteNames: Set<string>, acc: any[] = []): any[] => {
+    if (_.isArray(node)) {
+        node.forEach((n) => collectTableEntries(n, cteNames, acc));
+        return acc;
+    }
+    if (!_.isObject(node)) return acc;
+    const fromArr = _.get(node, "from");
+    if (_.isArray(fromArr)) {
+        _.forEach(fromArr, (entry: any) => {
+            const subquery = _.get(entry, "expr.ast");
+            if (subquery) {
+                collectTableEntries(subquery, cteNames, acc);
+                return;
+            }
+            const table = _.get(entry, "table");
+            if (_.isString(table) && !cteNames.has(table)) acc.push(entry);
+        });
+    }
+    // Walk every other key (with/_next/where/columns/...) to reach nested selects,
+    // but skip `from` to avoid re-visiting the entries handled above.
+    _.forEach(node, (value, key) => {
+        if (key !== "from") collectTableEntries(value, cteNames, acc);
+    });
+    return acc;
+};

--- a/command-service/Dockerfile.dhi
+++ b/command-service/Dockerfile.dhi
@@ -1,0 +1,36 @@
+# DHI hardened build on ALPINE (scans 0 vulns on both Docker Scout and trivy, vs debian's
+# unfixed-CVE noise). alpine-dev variant keeps a shell for kubectl/helm subprocess(shell=True).
+# confluent-kafka + psycopg2 compile from source against the apk build deps below.
+ARG BASE_IMAGE=dhi.io/python:3.12-alpine3.24-dev
+FROM ${BASE_IMAGE}
+ARG TARGETARCH
+
+RUN apk add --no-cache \
+    build-base \
+    gcc \
+    musl-dev \
+    python3-dev \
+    librdkafka-dev \
+    libpq-dev \
+    curl \
+    tar \
+    gzip \
+    ca-certificates \
+    bash
+
+RUN mkdir -p /usr/local/bin && \
+    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" && \
+    chmod +x kubectl && \
+    mv kubectl /usr/local/bin/
+
+RUN curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+COPY helm-charts ./helm-charts
+RUN chown -R nonroot:nonroot /app
+USER nonroot
+WORKDIR /app/src
+CMD [ "uvicorn", "routes:app", "--host", "0.0.0.0" ]

--- a/system-rules-ingestor/Dockerfile.hardened
+++ b/system-rules-ingestor/Dockerfile.hardened
@@ -1,0 +1,12 @@
+# DHI-hardened system-rules-ingestor (node batch job).
+# Build deps on the -dev variant (has npm), run on the minimal hardened node runtime.
+FROM dhi.io/node:20-alpine3.22-dev AS build
+WORKDIR /opt/app
+COPY package.json package-lock.json* ./
+RUN npm install --omit=dev --no-audit --no-fund
+COPY . .
+
+FROM dhi.io/node:20-alpine3.22
+WORKDIR /opt/app
+COPY --from=build /opt/app /opt/app
+CMD ["node", "index.js"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional SQL table-alias support that rewrites referenced identifiers to matching live datasource references before executing queries.
  * Alias resolution works across nested queries and common table expressions.
  * Added `sql_query_alias_support` configuration flag, defaulting to `"false"` when unset.
* **Bug Fixes**
  * If SQL parsing fails, is multi-statement, contains no table references, has no matching live datasources, or an error occurs, the original query is sent unchanged (with logging).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->